### PR TITLE
Change boot methods to match Eloquent boot[traitName] pattern.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cache/
 /bootstrap/compiled.php
 /vendor
 composer.phar
+composer.lock
 .DS_Store
 Thumbs.db
 

--- a/src/Laratrust/Traits/LaratrustPermissionTrait.php
+++ b/src/Laratrust/Traits/LaratrustPermissionTrait.php
@@ -34,10 +34,8 @@ trait LaratrustPermissionTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootLaratrustPermissionTrait()
     {
-        parent::boot();
-
         static::deleting(function ($permission) {
             if (!method_exists(Config::get('laratrust.permission'), 'bootSoftDeletes')) {
                 $permission->roles()->sync([]);

--- a/src/Laratrust/Traits/LaratrustRoleTrait.php
+++ b/src/Laratrust/Traits/LaratrustRoleTrait.php
@@ -66,10 +66,8 @@ trait LaratrustRoleTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootLaratrustRoleTrait()
     {
-        parent::boot();
-
         $flushCache = function ($role) {
             $role->flushCache();
             return true;

--- a/src/Laratrust/Traits/LaratrustUserTrait.php
+++ b/src/Laratrust/Traits/LaratrustUserTrait.php
@@ -53,10 +53,8 @@ trait LaratrustUserTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootLaratrustUserTrait()
     {
-        parent::boot();
-
         $flushCache = function ($user) {
             $user->flushCache();
             return true;


### PR DESCRIPTION
Because methods of traits used by the one class cannot have the same name there is a chance that(especially in User model) when using some other trait, it also implements `boot` method.

To avoid that I changed all `boot` methods to match Laravel Eloquent boot[traitName] pattern. 
It is automatically resolved so it acts exactly like a `boot` method. Also, you don't need to call `parent::boot`(actually you mustn't because it will crash everything) and most importantly it keeps you safe from method name conflicts.

I think this issue was raised in `Zizaco/Entrust` package but never addressed, so I'm doing this here.

I also added `composer.lock` file to `.gitignore` because who needs it.

Really looking forward to working with your fork.