### PR TITLE
Add `use LaratrustUserTrait` with a command call + some fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "php": ">=5.5.0",
         "illuminate/console": "~5.0",
         "illuminate/support": "~5.0",
-        "illuminate/cache": "~5.0"
+        "illuminate/cache": "~5.0",
+        "kkszymanowski/traitor": "^0.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",

--- a/src/Laratrust/LaratrustServiceProvider.php
+++ b/src/Laratrust/LaratrustServiceProvider.php
@@ -80,29 +80,29 @@ class LaratrustServiceProvider extends ServiceProvider
 
         // Call to Laratrust::hasRole
         $bladeCompiler->directive('role', function ($expression) {
-            return "<?php if (\\Laratrust::hasRole{$expression}) : ?>";
+            return "<?php if (app('laratrust')->hasRole{$expression}) : ?>";
         });
 
         $bladeCompiler->directive('endrole', function () {
-            return "<?php endif; // Laratrust::hasRole ?>";
+            return "<?php endif; // app('laratrust')->hasRole ?>";
         });
 
         // Call to Laratrust::can
         $bladeCompiler->directive('permission', function ($expression) {
-            return "<?php if (\\Laratrust::can{$expression}) : ?>";
+            return "<?php if (app('laratrust')->can{$expression}) : ?>";
         });
 
         $bladeCompiler->directive('endpermission', function () {
-            return "<?php endif; // Laratrust::can ?>";
+            return "<?php endif; // app('laratrust')->can ?>";
         });
 
         // Call to Laratrust::ability
         $bladeCompiler->directive('ability', function ($expression) {
-            return "<?php if (\\Laratrust::ability{$expression}) : ?>";
+            return "<?php if (app('laratrust')->ability{$expression}) : ?>";
         });
 
         $bladeCompiler->directive('endability', function () {
-            return "<?php endif; // Laratrust::ability ?>";
+            return "<?php endif; // app('laratrust')->ability ?>";
         });
     }
 

--- a/src/Laratrust/LaratrustServiceProvider.php
+++ b/src/Laratrust/LaratrustServiceProvider.php
@@ -11,6 +11,7 @@ namespace Santigarcor\Laratrust;
  */
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Factory;
 
 class LaratrustServiceProvider extends ServiceProvider
 {
@@ -22,22 +23,32 @@ class LaratrustServiceProvider extends ServiceProvider
     protected $defer = false;
 
     /**
+     * The commands to be registered.
+     *
+     * @var array
+     */
+    protected $commands = [
+        'Migration' => 'command.laratrust.migration',
+        'MakeRole' => 'command.laratrust.make-role',
+        'MakePermission' => 'command.laratrust.make-permission',
+        'AddLaratrustUserTraitUse' => 'command.laratrust.add-trait',
+        'Setup' => 'command.laratrust.setup'
+    ];
+
+    /**
      * Bootstrap the application events.
      *
+     * @param  Factory $view
      * @return void
      */
-    public function boot()
+    public function boot(Factory $view)
     {
-        // Publish config files
+        // Register published configuration.
         $this->publishes([
             __DIR__.'/../config/config.php' => config_path('laratrust.php'),
         ]);
 
-        // Register commands
-        $this->commands('command.laratrust.migration');
-        
-        // Register blade directives
-        $this->bladeDirectives();
+        $this->registerBladeDirectives($view);
     }
 
     /**
@@ -57,34 +68,40 @@ class LaratrustServiceProvider extends ServiceProvider
     /**
      * Register the blade directives
      *
+     * @param  Factory $view
      * @return void
      */
-    private function bladeDirectives()
+    private function registerBladeDirectives(Factory $view)
     {
+        // Fetch Blade Compiler off of the View\Factory
+        $bladeCompiler = $view->getEngineResolver()
+                              ->resolve('blade')
+                              ->getCompiler();
+
         // Call to Laratrust::hasRole
-        \Blade::directive('role', function ($expression) {
+        $bladeCompiler->directive('role', function ($expression) {
             return "<?php if (\\Laratrust::hasRole{$expression}) : ?>";
         });
 
-        \Blade::directive('endrole', function ($expression) {
+        $bladeCompiler->directive('endrole', function () {
             return "<?php endif; // Laratrust::hasRole ?>";
         });
 
         // Call to Laratrust::can
-        \Blade::directive('permission', function ($expression) {
+        $bladeCompiler->directive('permission', function ($expression) {
             return "<?php if (\\Laratrust::can{$expression}) : ?>";
         });
 
-        \Blade::directive('endpermission', function ($expression) {
+        $bladeCompiler->directive('endpermission', function () {
             return "<?php endif; // Laratrust::can ?>";
         });
 
         // Call to Laratrust::ability
-        \Blade::directive('ability', function ($expression) {
+        $bladeCompiler->directive('ability', function ($expression) {
             return "<?php if (\\Laratrust::ability{$expression}) : ?>";
         });
 
-        \Blade::directive('endability', function ($expression) {
+        $bladeCompiler->directive('endability', function () {
             return "<?php endif; // Laratrust::ability ?>";
         });
     }
@@ -99,19 +116,58 @@ class LaratrustServiceProvider extends ServiceProvider
         $this->app->bind('laratrust', function ($app) {
             return new Laratrust($app);
         });
-        
+
         $this->app->alias('laratrust', 'Santigarcor\Laratrust\Laratrust');
     }
 
     /**
-     * Register the artisan commands.
+     * Register the given commands.
      *
      * @return void
      */
-    private function registerCommands()
+    protected function registerCommands()
     {
-        $this->app->singleton('command.laratrust.migration', function ($app) {
+        foreach (array_keys($this->commands) as $command) {
+            $method = "register{$command}Command";
+
+            call_user_func_array([$this, $method], []);
+        }
+
+        $this->commands(array_values($this->commands));
+    }
+    
+    protected function registerMigrationCommand()
+    {
+        $this->app->singleton('command.laratrust.migration', function () {
             return new MigrationCommand();
+        });
+    }
+    
+    protected function registerMakeRoleCommand()
+    {
+        $this->app->singleton('command.laratrust.make-role', function ($app) {
+            return new MakeRoleCommand($app['files']);
+        });
+    }
+    
+    protected function registerMakePermissionCommand()
+    {
+        $this->app->singleton('command.laratrust.make-permission', function ($app) {
+            return new MakePermissionCommand($app['files']);
+        });
+    }
+    
+    protected function registerAddLaratrustUserTraitUseCommand()
+    {
+        $this->app->singleton('command.laratrust.add-trait', function () {
+            return new AddLaratrustUserTraitUseCommand();
+        });
+    }
+    
+    protected function registerSetupCommand()
+    {
+        $this->app->singleton('command.laratrust.setup', function () {
+            return new SetupCommand();
         });
     }
 
@@ -135,8 +191,6 @@ class LaratrustServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [
-            'command.laratrust.migration'
-        ];
+        return array_values($this->commands);
     }
 }

--- a/src/commands/AddLaratrustUserTraitUseCommand.php
+++ b/src/commands/AddLaratrustUserTraitUseCommand.php
@@ -2,6 +2,14 @@
 
 namespace Santigarcor\Laratrust;
 
+/**
+ * This file is part of Laratrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Santigarcor\Laratrust
+ */
+
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Config;
 use Santigarcor\Laratrust\Traits\LaratrustUserTrait;
@@ -70,5 +78,4 @@ class AddLaratrustUserTraitUseCommand extends Command
     {
         return Config::get('auth.providers.users.model', 'App\User');
     }
-
 }

--- a/src/commands/AddLaratrustUserTraitUseCommand.php
+++ b/src/commands/AddLaratrustUserTraitUseCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Santigarcor\Laratrust;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+use Santigarcor\Laratrust\Traits\LaratrustUserTrait;
+use Traitor\Traitor;
+
+class AddLaratrustUserTraitUseCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'laratrust:add-trait';
+
+    /**
+     * Trait added to User model
+     *
+     * @var string
+     */
+    protected $targetTrait = LaratrustUserTrait::class;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $userModel = $this->getUserModel();
+        
+        if (! class_exists($userModel)) {
+            $this->error("Class $userModel does not exist.");
+            return;
+        }
+
+        if ($this->alreadyUsesLaratrustUserTrait()) {
+            $this->error("Class $userModel already uses LaratrustUserTrait.");
+            return;
+        }
+
+        Traitor::addTrait($this->targetTrait)->toClass($userModel);
+
+        $this->info("LaratrustUserTrait added successfully");
+    }
+
+    /**
+     * @return bool
+     */
+    protected function alreadyUsesLaratrustUserTrait()
+    {
+        return in_array(LaratrustUserTrait::class, class_uses($this->getUserModel()));
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return "Add LaratrustUserTrait to {$this->getUserModel()} class";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getUserModel()
+    {
+        return Config::get('auth.providers.users.model', 'App\User');
+    }
+
+}

--- a/src/commands/MakePermissionCommand.php
+++ b/src/commands/MakePermissionCommand.php
@@ -2,9 +2,15 @@
 
 namespace Santigarcor\Laratrust;
 
-use Illuminate\Support\Str;
+/**
+ * This file is part of Laratrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Santigarcor\Laratrust
+ */
+
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class MakePermissionCommand extends GeneratorCommand
 {
@@ -79,5 +85,4 @@ class MakePermissionCommand extends GeneratorCommand
     {
         return [];
     }
-
 }

--- a/src/commands/MakePermissionCommand.php
+++ b/src/commands/MakePermissionCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Santigarcor\Laratrust;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class MakePermissionCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'laratrust:make-permission';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create Permission model if it does not exist';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Permission model';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        parent::fire();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/permission.stub';
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return 'Permission';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+}

--- a/src/commands/MakeRoleCommand.php
+++ b/src/commands/MakeRoleCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Santigarcor\Laratrust;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class MakeRoleCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'laratrust:make-role';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create Role model if it does not exist';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Role model';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        parent::fire();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/role.stub';
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return 'Role';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace;
+    }
+    
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+}

--- a/src/commands/MakeRoleCommand.php
+++ b/src/commands/MakeRoleCommand.php
@@ -2,9 +2,15 @@
 
 namespace Santigarcor\Laratrust;
 
-use Illuminate\Support\Str;
+/**
+ * This file is part of Laratrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Santigarcor\Laratrust
+ */
+
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class MakeRoleCommand extends GeneratorCommand
 {
@@ -79,5 +85,4 @@ class MakeRoleCommand extends GeneratorCommand
     {
         return [];
     }
-
 }

--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -30,6 +30,13 @@ class MigrationCommand extends Command
     protected $description = 'Creates a migration following the Laratrust specifications.';
 
     /**
+     * Suffix of the migration name.
+     *
+     * @var string
+     */
+    protected $migrationSuffix = 'laratrust_setup_tables';
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -54,35 +61,50 @@ class MigrationCommand extends Command
         );
 
         $this->comment($message);
+
+        $existingMigrations = $this->alreadyExistingMigrations();
+
+        if($existingMigrations) {
+            $this->line('');
+            
+            $this->warn($this->getExistingMigrationsWarning($existingMigrations));
+        }
+
         $this->line('');
 
-        if ($this->confirm("Proceed with the migration creation? [Yes|no]", "Yes")) {
-            $this->line('');
-
-            $this->info("Creating migration...");
-            if ($this->createMigration($rolesTable, $roleUserTable, $permissionsTable, $permissionRoleTable)) {
-                $this->info("Migration successfully created!");
-            } else {
-                $this->error(
-                    "Couldn't create migration.\n Check the write permissions".
-                    " within the database/migrations directory."
-                );
-            }
-
-            $this->line('');
+        if (! $this->confirm("Proceed with the migration creation?", "yes")) {
+            return;
         }
+
+        $this->line('');
+
+        $this->info("Creating migration...");
+
+        if ($this->createMigration($rolesTable, $roleUserTable, $permissionsTable, $permissionRoleTable)) {
+            $this->info("Migration successfully created!");
+        } else {
+            $this->error(
+                "Couldn't create migration.\n".
+                "Check the write permissions within the database/migrations directory."
+            );
+        }
+
+        $this->line('');
+
     }
 
     /**
      * Create the migration.
      *
-     * @param string $name
-     *
+     * @param  string $rolesTable
+     * @param  string $roleUserTable
+     * @param  string $permissionsTable
+     * @param  string $permissionRoleTable
      * @return bool
      */
     protected function createMigration($rolesTable, $roleUserTable, $permissionsTable, $permissionRoleTable)
     {
-        $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_laratrust_setup_tables.php";
+        $migrationPath = $this->getMigrationPath();
 
         $usersTable  = Config::get('auth.providers.users.table') ?: 'users';
         $userModel   = Config::get('auth.providers.users.model');
@@ -99,7 +121,7 @@ class MigrationCommand extends Command
 
         $output = $this->laravel->view->make('laratrust::generators.migration')->with($data)->render();
 
-        if (!file_exists($migrationFile) && $fs = fopen($migrationFile, 'x')) {
+        if (!file_exists($migrationPath) && $fs = fopen($migrationPath, 'x')) {
             fwrite($fs, $output);
             fclose($fs);
             return true;
@@ -111,16 +133,68 @@ class MigrationCommand extends Command
     /**
      * Generate the message to display when running the
      * console command showing what tables are going
-     * to be created
+     * to be created.
+     *
      * @param  string $rolesTable
      * @param  string $roleUserTable
      * @param  string $permissionsTable
      * @param  string $permissionRoleTable
      * @return string
      */
-    public function generateMigrationMessage($rolesTable, $roleUserTable, $permissionsTable, $permissionRoleTable)
+    protected function generateMigrationMessage($rolesTable, $roleUserTable, $permissionsTable, $permissionRoleTable)
     {
         return "A migration that creates '$rolesTable', '$roleUserTable', '$permissionsTable', '$permissionRoleTable'".
-        " tables will be created in database/migrations directory";
+            " tables will be created in database/migrations directory";
+    }
+
+    /**
+     * Build a warning regarding possible duplication
+     * due to already existing migrations
+     *
+     * @param  array $existingMigrations
+     * @return string
+     */
+    protected function getExistingMigrationsWarning(array $existingMigrations)
+    {
+        if (count($existingMigrations) > 1) {
+            $base = "Laratrust migrations already exist.\nFollowing files were found: ";
+        } else {
+            $base = "Laratrust migration already exists.\nFollowing file was found: ";
+        }
+
+        return $base . array_reduce($existingMigrations, function($carry, $fileName) {
+            return $carry . "\n - " . $fileName;
+        });
+    }
+
+    /**
+     * Check if there is another migration
+     * with the same suffix.
+     *
+     * @return array
+     */
+    protected function alreadyExistingMigrations()
+    {
+        $matchingFiles = glob($this->getMigrationPath('*'));
+
+        return array_map(function($path) {
+            return basename($path);
+        }, $matchingFiles);
+    }
+
+    /**
+     * Get the migration path.
+     *
+     * The date parameter is optional for ability
+     * to provide a custom value or a wildcard.
+     *
+     * @param  string|null $date
+     * @return string
+     */
+    protected function getMigrationPath($date = null)
+    {
+        $date = $date ?: date('Y_m_d_His');
+
+        return database_path("migrations/${date}_{$this->migrationSuffix}.php");
     }
 }

--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -64,7 +64,7 @@ class MigrationCommand extends Command
 
         $existingMigrations = $this->alreadyExistingMigrations();
 
-        if($existingMigrations) {
+        if ($existingMigrations) {
             $this->line('');
             
             $this->warn($this->getExistingMigrationsWarning($existingMigrations));
@@ -162,7 +162,7 @@ class MigrationCommand extends Command
             $base = "Laratrust migration already exists.\nFollowing file was found: ";
         }
 
-        return $base . array_reduce($existingMigrations, function($carry, $fileName) {
+        return $base . array_reduce($existingMigrations, function ($carry, $fileName) {
             return $carry . "\n - " . $fileName;
         });
     }
@@ -177,7 +177,7 @@ class MigrationCommand extends Command
     {
         $matchingFiles = glob($this->getMigrationPath('*'));
 
-        return array_map(function($path) {
+        return array_map(function ($path) {
             return basename($path);
         }, $matchingFiles);
     }

--- a/src/commands/SetupCommand.php
+++ b/src/commands/SetupCommand.php
@@ -2,11 +2,15 @@
 
 namespace Santigarcor\Laratrust;
 
-use App\User;
+/**
+ * This file is part of Laratrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Santigarcor\Laratrust
+ */
+
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
-use Santigarcor\Laratrust\Traits\LaratrustUserTrait;
-use Traitor\Traitor;
 
 class SetupCommand extends Command
 {
@@ -43,10 +47,9 @@ class SetupCommand extends Command
      */
     public function fire()
     {
-        foreach($this->calls as $command => $info) {
+        foreach ($this->calls as $command => $info) {
             $this->line(PHP_EOL . $info);
             $this->call($command);
         }
     }
-
 }

--- a/src/commands/SetupCommand.php
+++ b/src/commands/SetupCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Santigarcor\Laratrust;
+
+use App\User;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Santigarcor\Laratrust\Traits\LaratrustUserTrait;
+use Traitor\Traitor;
+
+class SetupCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'laratrust:setup';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Setup migration and models for Laratrust';
+
+    /**
+     * Commands to call with their description
+     *
+     * @var array
+     */
+    protected $calls = [
+        'laratrust:migration' => 'Creating migration',
+        'laratrust:make-role' => 'Creating Role model',
+        'laratrust:make-permission' => 'Creating Permission model',
+        'laratrust:add-trait' => 'Adding LaratrustUserTrait to User model'
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        foreach($this->calls as $command => $info) {
+            $this->line(PHP_EOL . $info);
+            $this->call($command);
+        }
+    }
+
+}

--- a/src/commands/stubs/permission.stub
+++ b/src/commands/stubs/permission.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Santigarcor\Laratrust\LaratrustPermission;
+
+class Permission extends LaratrustPermission
+{
+    //
+}

--- a/src/commands/stubs/role.stub
+++ b/src/commands/stubs/role.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Santigarcor\Laratrust\LaratrustRole;
+
+class Role extends LaratrustRole
+{
+    //
+}


### PR DESCRIPTION
Hi

Regarding issue https://github.com/santigarcor/laratrust/issues/3:

### New commands
- `laratrust:make-role` - Creates a Role model based on a stub
- `laratrust:make-permission` - As above, creates a Permission model
- `laratrust:add-trait` - Adds a `LaratrustUserTrat` use statement to User model in a manner described  [here](https://github.com/KKSzymanowski/Traitor/blob/master/README.md#behavior) (class name taken from config, so not necessarily \App\User)
- `laratrust:setup` - Calls(in that order) following commands, informing before each step what is going to happen now.
    * `laratrust:migration`
    * `laratrust:make-role`
    * `laratrust:make-permission`
    * `laratrust:add-trait`

Here's how it works, in HD of course:
[![Laratrust setup](https://img.youtube.com/vi/c_JaqgktuL8/0.jpg)](https://www.youtube.com/watch?v=c_JaqgktuL8)

### Major fixes
- **Replace `\Laratrust` call from blade directive with `app('laratrust')`.**

The reason is, user isn't supposed to be obligated to add an `alias` so we cannot rely on it's existance. I know Zizaco implemented it with a an `alias`, but take a look for example at the [@lang](https://github.com/laravel/framework/blob/d679a3d789d1d1e535bdce189893b5a9bb6a001b/src/Illuminate/View/Compilers/BladeCompiler.php#L536) directive. It's exactly what I've done.
- **Warn user if the Laratrust migration already exists.**

Do you think we should block duplication, not just warn about it?
_I think it can be more reliable by checking if `LaratrustSetupTables` class exists, but for now I think it's fine._

### Minor fixes
- **Resolve `BladeCompiler` out of IoC container instead of accessing it via a Facade.** 

I personally agree that using Facades([or whatever you might wanna call it](https://www.reddit.com/r/PHP/comments/1zpm0y/laravel_lets_talk_about_facades)) can implicate bad programming habbits([Taylor on Facades](http://taylorotwell.com/response-dont-use-facades/)) and when they're not necessary, they should be replaced with Dependency Injection. That's one reason. Second reason why I did it this way is the sheer performance gain.
- **Updated DocBlocks**

<hr>

To be honest, `Traitor` is my first serious composer package and this is my first serious GitHub contribution so feel free to point out any mistakes or ways to improve this proposal.

`Traitor` is quite heavily tested so there souldn't be any problems on it's side. However I couldn't figure out how to test these commands. Do you have some ideas?