### PR TITLE
Normalize the Laravel Version Identifier

### DIFF
--- a/src/Laratrust/LaratrustRegistersBladeDirectives.php
+++ b/src/Laratrust/LaratrustRegistersBladeDirectives.php
@@ -24,7 +24,7 @@ class LaratrustRegistersBladeDirectives
      */
     public function handle($laravelVersion = '5.3.0')
     {
-        if (version_compare($laravelVersion, '5.3.0-dev', '>=')) {
+        if (version_compare(strtolower($laravelVersion), '5.3.0-dev', '>=')) {
             $this->registerWithParenthesis();
         } else {
             $this->registerWithoutParenthesis();


### PR DESCRIPTION
With the current `version_compare`, if Laravel changes the casing of the version identifier, it will break this comparison. Using a `strtolower` function to normalize the internal version number.