### PR TITLE
Add fk to pivot relationship

### DIFF
--- a/src/Laratrust/Traits/LaratrustPermissionTrait.php
+++ b/src/Laratrust/Traits/LaratrustPermissionTrait.php
@@ -23,7 +23,9 @@ trait LaratrustPermissionTrait
     {
         return $this->belongsToMany(
             Config::get('laratrust.role'),
-            Config::get('laratrust.permission_role_table')
+            Config::get('laratrust.permission_role_table'),
+            Config::get('laratrust.permission_foreign_key'),
+            Config::get('laratrust.role_foreign_key')
         );
     }
 


### PR DESCRIPTION
There are config values for foreign keys in pivot tables,
but they are not used in declaration of relationship. Fix it.