### PR TITLE
Properly seed roles with more than one word

### DIFF
--- a/src/views/generators/seeder.blade.php
+++ b/src/views/generators/seeder.blade.php
@@ -24,8 +24,8 @@ class LaratrustSeeder extends Seeder
             // Create a new role
             $role = \{{ $role }}::create([
                 'name' => $key,
-                'display_name' => ucfirst($key),
-                'description' => ucfirst($key)
+                'display_name' => ucwords(str_replace("_", " ", $key)),
+                'description' => ucwords(str_replace("_", " ", $key))
             ]);
 
             $this->command->info('Creating Role '. strtoupper($key));


### PR DESCRIPTION
A role with the key `some_name` will be seeded as `'description' => 'Some_name'` and `'display_name' => 'Some_name'`. This proposed change will allow for roles where the words are separated by an underscore to be correctly displayed.