### PR TITLE
Refactoring migrations

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -43,11 +43,11 @@ class LaratrustSetupTables extends Migration
 @endif
         // Create table for associating roles to users and teams (Many To Many Polymorphic)
         Schema::create('{{ $laratrust['tables']['role_user'] }}', function (Blueprint $table) {
-            $table->integer('{{ $laratrust['foreign_keys']['user'] }}')->unsigned();
-            $table->integer('{{ $laratrust['foreign_keys']['role'] }}')->unsigned();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['role'] }}');
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['user'] }}');
             $table->string('user_type');
 @if ($laratrust['use_teams'])
-            $table->integer('{{ $laratrust['foreign_keys']['team'] }}')->unsigned()->nullable();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
 @endif
 
             $table->foreign('{{ $laratrust['foreign_keys']['role'] }}')->references('id')->on('{{ $laratrust['tables']['roles'] }}')
@@ -65,11 +65,11 @@ class LaratrustSetupTables extends Migration
 
         // Create table for associating permissions to users (Many To Many Polymorphic)
         Schema::create('{{ $laratrust['tables']['permission_user'] }}', function (Blueprint $table) {
-            $table->integer('{{ $laratrust['foreign_keys']['user'] }}')->unsigned();
-            $table->integer('{{ $laratrust['foreign_keys']['permission'] }}')->unsigned();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['permission'] }}');
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['user'] }}');
             $table->string('user_type');
 @if ($laratrust['use_teams'])
-            $table->integer('{{ $laratrust['foreign_keys']['team'] }}')->unsigned()->nullable();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
 @endif
 
             $table->foreign('{{ $laratrust['foreign_keys']['permission'] }}')->references('id')->on('{{ $laratrust['tables']['permissions'] }}')
@@ -87,8 +87,8 @@ class LaratrustSetupTables extends Migration
 
         // Create table for associating permissions to roles (Many-to-Many)
         Schema::create('{{ $laratrust['tables']['permission_role'] }}', function (Blueprint $table) {
-            $table->integer('{{ $laratrust['foreign_keys']['permission'] }}')->unsigned();
-            $table->integer('{{ $laratrust['foreign_keys']['role'] }}')->unsigned();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['permission'] }}');
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['role'] }}');
 
             $table->foreign('{{ $laratrust['foreign_keys']['permission'] }}')->references('id')->on('{{ $laratrust['tables']['permissions'] }}')
                 ->onUpdate('cascade')->onDelete('cascade');

--- a/src/views/generators/setup-teams.blade.php
+++ b/src/views/generators/setup-teams.blade.php
@@ -27,7 +27,7 @@ class LaratrustSetupTeams extends Migration
             $table->dropPrimary(['{{ $laratrust['foreign_keys']['user'] }}', '{{ $laratrust['foreign_keys']['role'] }}', 'user_type']);
 
             // Add {{ $laratrust['foreign_keys']['team'] }} column
-            $table->integer('{{ $laratrust['foreign_keys']['team'] }}')->unsigned()->nullable();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
 
             // Create foreign keys
             $table->foreign('{{ $laratrust['foreign_keys']['role'] }}')->references('id')->on('{{ $laratrust['tables']['roles'] }}')
@@ -48,7 +48,7 @@ class LaratrustSetupTeams extends Migration
                 ->onUpdate('cascade')->onDelete('cascade');
 
             // Add {{ $laratrust['foreign_keys']['team'] }} column
-            $table->integer('{{ $laratrust['foreign_keys']['team'] }}')->unsigned()->nullable();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
 
             $table->foreign('{{ $laratrust['foreign_keys']['team'] }}')->references('id')->on('{{ $laratrust['tables']['teams'] }}')
                 ->onUpdate('cascade')->onDelete('cascade');

--- a/src/views/generators/upgrade-migration.blade.php
+++ b/src/views/generators/upgrade-migration.blade.php
@@ -28,7 +28,7 @@ class LaratrustUpgradeTables extends Migration
             $table->dropPrimary(['{{ $laratrust['foreign_keys']['user'] }}', '{{ $laratrust['foreign_keys']['role'] }}', 'user_type']);
 
             // Add {{ $laratrust['foreign_keys']['team'] }} column
-            $table->integer('{{ $laratrust['foreign_keys']['team'] }}')->unsigned()->nullable();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
 
             // Create foreign keys
             $table->foreign('{{ $laratrust['foreign_keys']['role'] }}')->references('id')->on('{{ $laratrust['tables']['roles'] }}')
@@ -51,7 +51,7 @@ class LaratrustUpgradeTables extends Migration
 
 @if ($laratrust['use_teams'])
             // Add {{ $laratrust['foreign_keys']['team'] }} column
-            $table->integer('{{ $laratrust['foreign_keys']['team'] }}')->unsigned()->nullable();
+            $table->unsignedInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
 
             $table->foreign('{{ $laratrust['foreign_keys']['team'] }}')->references('id')->on('{{ $laratrust['tables']['teams'] }}')
                 ->onUpdate('cascade')->onDelete('cascade');


### PR DESCRIPTION
Use the shorthand method `unsignedInteger()` as shown in the [Available Column Types](https://laravel.com/docs/5.4/migrations#columns) for migrations.

And in `migration.blade.php`, use alphabetical order!

 😄 