### PR TITLE
add compatibility for roles and permission access to all teams

### DIFF
--- a/src/Laratrust/Traits/LaratrustUserTrait.php
+++ b/src/Laratrust/Traits/LaratrustUserTrait.php
@@ -736,7 +736,7 @@ trait LaratrustUserTrait
      */
     private function isInSameTeam($rolePermission, $team)
     {
-        if (!Config::get('laratrust.use_teams')) {
+        if (!Config::get('laratrust.use_teams') || is_null($team)) {
             return true;
         }
 


### PR DESCRIPTION
It has come to my attention that when you use the team feature, the isInSameTeam function will return false in the event that a role or permission relation with a user does not have a team assigned (null). In my current project I have to requirement of having some roles / permissions that apply for all teams. And the way that I do this is by leaving team unassigned.

I have made adjustments in the method so that it will check if team is null, in which case the method will return true, thus the user will have the permissions.