### PR TITLE
Use Laravel standard for enable and disable foreign key checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "santigarcor/laratrust",
     "description": "This package provides a flexible way to add Role-based Permissions to Laravel",
-    "keywords": ["acl", "authorization", "laravel","laratrust","permissions","php", "rbac","roles"],
+    "keywords": ["acl", "authorization", "laravel","laratrust","permissions","php", "rbac","roles", "multiusers", "teams"],
     "license": "MIT",
     "authors": [
         {
@@ -15,7 +15,7 @@
         "illuminate/cache": "~5.2",
         "illuminate/console": "~5.2",
         "illuminate/database": "~5.2",
-        "illuminate/support": "^5.2",
+        "illuminate/support": "~5.2",
         "kkszymanowski/traitor": "^0.2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/auth": "~5.2",
         "illuminate/cache": "~5.2",
         "illuminate/console": "~5.2",
-        "illuminate/database": "~5.2",
+        "illuminate/database": "^5.2.32",
         "illuminate/support": "~5.2",
         "kkszymanowski/traitor": "^0.2.0"
     },

--- a/src/views/generators/seeder.blade.php
+++ b/src/views/generators/seeder.blade.php
@@ -107,7 +107,7 @@ class LaratrustSeeder extends Seeder
      */
     public function truncateLaratrustTables()
     {
-        Schema::enableForeignKeyConstraints();
+        Schema::disableForeignKeyConstraints();
 @if (Config::get('database.default') == 'pgsql')
         DB::table('{{ config('laratrust.tables.permission_role') }}')->truncate();
         DB::table('{{ config('laratrust.tables.permission_user') }}')->truncate();
@@ -118,14 +118,7 @@ class LaratrustSeeder extends Seeder
         DB::statement("TRUNCATE TABLE {$usersTable} CASCADE");
         DB::statement("TRUNCATE TABLE {$rolesTable} CASCADE");
         DB::statement("TRUNCATE TABLE {$permissionsTable} CASCADE");
-@elseif(Config::get('database.default') == 'mysql')
-        DB::table('{{ config('laratrust.tables.permission_role') }}')->truncate();
-        DB::table('{{ config('laratrust.tables.permission_user') }}')->truncate();
-        DB::table('{{ config('laratrust.tables.role_user') }}')->truncate();
-        \{{ $user }}::truncate();
-        \{{ $role }}::truncate();
-        \{{ $permission }}::truncate();
-@elseif(Config::get('database.default') == 'sqlsrv')
+@else
         DB::table('{{ config('laratrust.tables.permission_role') }}')->truncate();
         DB::table('{{ config('laratrust.tables.permission_user') }}')->truncate();
         DB::table('{{ config('laratrust.tables.role_user') }}')->truncate();
@@ -133,6 +126,6 @@ class LaratrustSeeder extends Seeder
         \{{ $role }}::truncate();
         \{{ $permission }}::truncate();
 @endif
-        Schema::disableForeignKeyConstraints();
+        Schema::enableForeignKeyConstraints();
     }
 }

--- a/src/views/generators/seeder.blade.php
+++ b/src/views/generators/seeder.blade.php
@@ -1,5 +1,6 @@
 <?php echo '<?php' ?>
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -106,6 +107,7 @@ class LaratrustSeeder extends Seeder
      */
     public function truncateLaratrustTables()
     {
+        Schema::enableForeignKeyConstraints();
 @if (Config::get('database.default') == 'pgsql')
         DB::table('{{ config('laratrust.tables.permission_role') }}')->truncate();
         DB::table('{{ config('laratrust.tables.permission_user') }}')->truncate();
@@ -117,23 +119,20 @@ class LaratrustSeeder extends Seeder
         DB::statement("TRUNCATE TABLE {$rolesTable} CASCADE");
         DB::statement("TRUNCATE TABLE {$permissionsTable} CASCADE");
 @elseif(Config::get('database.default') == 'mysql')
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
         DB::table('{{ config('laratrust.tables.permission_role') }}')->truncate();
         DB::table('{{ config('laratrust.tables.permission_user') }}')->truncate();
         DB::table('{{ config('laratrust.tables.role_user') }}')->truncate();
         \{{ $user }}::truncate();
         \{{ $role }}::truncate();
         \{{ $permission }}::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1');
 @elseif(Config::get('database.default') == 'sqlsrv')
-        DB::statement('EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"');
         DB::table('{{ config('laratrust.tables.permission_role') }}')->truncate();
         DB::table('{{ config('laratrust.tables.permission_user') }}')->truncate();
         DB::table('{{ config('laratrust.tables.role_user') }}')->truncate();
         \{{ $user }}::truncate();
         \{{ $role }}::truncate();
         \{{ $permission }}::truncate();
-        DB::statement('EXEC sp_msforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"');
 @endif
+        Schema::disableForeignKeyConstraints();
     }
 }


### PR DESCRIPTION
Instead of checking what database the dev is using, and modifying the foreign key constraints, let's leave [Laravel to handle this by default](https://laravel.com/docs/5.4/migrations#foreign-key-constraints)