### PR TITLE
[5.0] Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "kkszymanowski/traitor": "^0.2.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.2",
+        "mockery/mockery": ">=0.9.9",
         "phpunit/phpunit": ">=4.1",
         "orchestra/testbench": "~3.2"
     },


### PR DESCRIPTION
Update `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0) and drop support for PHP `5.5.9`, as Mockery [requires PHP `5.6`](https://github.com/mockery/mockery/blob/master/composer.json#L31).