### PR TITLE
Clean else

### DIFF
--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -338,9 +338,9 @@ trait LaratrustUserTrait
             return $validateAll;
         } elseif ($options['return_type'] == 'array') {
             return ['roles' => $checkedRoles, 'permissions' => $checkedPermissions];
-        } else {
-            return [$validateAll, ['roles' => $checkedRoles, 'permissions' => $checkedPermissions]];
         }
+
+        return [$validateAll, ['roles' => $checkedRoles, 'permissions' => $checkedPermissions]];
     }
 
     /**


### PR DESCRIPTION
I've removed the `else`s when we have already returned something :put_litter_in_its_place:

We can also enable `no_useless_else` in `StyleCI`. Should we?