### PR TITLE
don't retrieve team relationship if not using teams

### DIFF
--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -120,19 +120,18 @@ trait LaratrustUserTrait
      */
     public function rolesTeams()
     {
-        if (Config::get('laratrust.use_teams')) {
-            $teams = $this->morphToMany(
+        if (!Config::get('laratrust.use_teams')) {
+            return null;
+        }
+
+        return $this->morphToMany(
                 Config::get('laratrust.models.team'),
                 'user',
                 Config::get('laratrust.tables.role_user'),
                 Config::get('laratrust.foreign_keys.user'),
                 Config::get('laratrust.foreign_keys.team')
-            );
-
-            return $teams;
-        }
-        
-        return null;
+            )
+            ->withPivot(Config::get('laratrust.foreign_keys.role'));
     }
 
     /**

--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -120,15 +120,19 @@ trait LaratrustUserTrait
      */
     public function rolesTeams()
     {
-        $teams = $this->morphToMany(
-            Config::get('laratrust.models.team'),
-            'user',
-            Config::get('laratrust.tables.role_user'),
-            Config::get('laratrust.foreign_keys.user'),
-            Config::get('laratrust.foreign_keys.team')
-        );
+        if (Config::get('laratrust.use_teams')) {
+            $teams = $this->morphToMany(
+                Config::get('laratrust.models.team'),
+                'user',
+                Config::get('laratrust.tables.role_user'),
+                Config::get('laratrust.foreign_keys.user'),
+                Config::get('laratrust.foreign_keys.team')
+            );
 
-        return $teams;
+            return $teams;
+        }
+        
+        return null;
     }
 
     /**

--- a/tests/LaratrustUserTest.php
+++ b/tests/LaratrustUserTest.php
@@ -73,10 +73,7 @@ class LaratrustUserTest extends LaratrustTestCase
         |------------------------------------------------------------
         */
         $this->app['config']->set('laratrust.use_teams', false);
-        $this->assertInstanceOf(
-            'Illuminate\Database\Eloquent\Relations\MorphToMany',
-            $this->user->rolesTeams()
-        );
+        $this->assertNull($this->user->rolesTeams());
 
         $this->app['config']->set('laratrust.use_teams', true);
         $this->assertInstanceOf(
@@ -851,8 +848,8 @@ class LaratrustUserTest extends LaratrustTestCase
         |------------------------------------------------------------
         */
         $roleA = Role::create(['name' => 'role_a']);
-        $roleB =  Role::create(['name' => 'role_b']);
-        $permissionA =  Permission::create(['name' => 'permission_a']);
+        $roleB = Role::create(['name' => 'role_b']);
+        $permissionA = Permission::create(['name' => 'permission_a']);
         $permissionB = Permission::create(['name' => 'permission_b']);
         $permissionC = Permission::create(['name' => 'permission_c']);
 


### PR DESCRIPTION
Hi, I just upgraded to Laratrust 5.0.6 and found a small bug. I'm using barryvdh's ide-helper, and when the composer afterUpdate method ran, ide-helper tried to retrieve all the Eloquent relationships, and crashed when it got to the rolesTeams relationship, since I am not using teams and I don't have that model.