### PR TITLE
Fixed bug: using custom $primaryKey in Laratrust models.

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -167,7 +167,9 @@ class Helper
         }
 
         $model = new $class;
-        $model->setAttribute('id', $data['id'])->setAttribute('name', $data['name']);
+        $primaryKey = $model->getKeyName();
+
+        $model->setAttribute($primaryKey, $data[$primaryKey])->setAttribute('name', $data['name']);
         $model->setRelation(
             'pivot',
             MorphPivot::fromRawAttributes($model, $data['pivot'], 'pivot_table')


### PR DESCRIPTION
This is a fix of the bug reported in the issue #256 (*"Problem using 'can' method after customize the primary key of Laratrust generated models"*).