### PR TITLE
Add new params to LaratrustMiddleware for redirects

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -191,17 +191,22 @@ return [
         'handling' => 'abort',
 
         /**
-	 * Parameter passed to the middleware_handling method.
-	 * If message is blank no message is passed to the session.
-	 * destination and message only used on redirect.
+         * Parameter passed to the middleware_handling method.
+         * If message is blank no message is passed to the session.
+         * destination and message only used on redirect.
          */
-	'params' => [
-		'status' => '403',
-		'destination'=>'/home', 
-		'message' => '',
-		'message_type' => 'error'
-	],
-
+        'handlers' => [
+            'abort' => [
+                'code' => 403
+            ],
+            'redirect' => [
+                'url' => '/home',
+                'message' => [
+                    'type' => 'error',
+                    'content' => ''
+                ]
+            ]
+        ]
     ],
 
     /*

--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -191,9 +191,16 @@ return [
         'handling' => 'abort',
 
         /**
-         * Parameter passed to the middleware_handling method
+	 * Parameter passed to the middleware_handling method.
+	 * If message is blank no message is passed to the session.
+	 * destination and message only used on redirect.
          */
-        'params' => '403',
+	'params' => [
+		'status' => '403',
+		'destination'=>'/home', 
+		'message' => '',
+		'message_type' => 'error'
+	],
 
     ],
 

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -45,10 +45,14 @@ class LaratrustMiddleware
         $parameter = Config::get('laratrust.middleware.params');
 
         if (Config::get('laratrust.middleware.handling') == 'abort') {
-            return App::abort($parameter);
+            return App::abort($parameter['status']);
         }
 
-        return Redirect::to($parameter);
+	$redirect = Redirect::to($parameter['destination']);
+	if(!empty($parameter['message'])) {
+		$redirect->with($parameter['message_type'], $parameter['message']);
+	}
+	return $redirect;
     }
 
     /**

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -42,17 +42,17 @@ class LaratrustMiddleware
      */
     protected function unauthorized()
     {
-        $parameter = Config::get('laratrust.middleware.params');
+        $parameter = Config::get('laratrust.middleware.handlers');
 
         if (Config::get('laratrust.middleware.handling') == 'abort') {
-            return App::abort($parameter['status']);
+            return App::abort($parameter['abort']['code']);
         }
 
-	$redirect = Redirect::to($parameter['destination']);
-	if(!empty($parameter['message'])) {
-		$redirect->with($parameter['message_type'], $parameter['message']);
-	}
-	return $redirect;
+        $redirect = Redirect::to($parameter['redirect']['url']);
+        if(!empty($parameter['redirect']['message']['content'])) {
+            $redirect->with($parameter['redirect']['message']['type'], $parameter['redirect']['message']['content']);
+        }
+        return $redirect;
     }
 
     /**

--- a/tests/Middleware/LaratrustPermissionTest.php
+++ b/tests/Middleware/LaratrustPermissionTest.php
@@ -2,6 +2,8 @@
 
 namespace Laratrust\Tests\Middleware;
 
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Session;
 use Mockery as m;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
@@ -135,5 +137,115 @@ class LaratrustPermissionTest extends MiddlewareTest
 
         $this->assertNull($middleware->handle($this->request, function () {
         }, 'users-create|users-update', 'TeamA', 'guard:api|require_all'));
+    }
+
+    public function testHandle_IsLoggedInWithNoPermission_ShouldRedirectWithError()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        Session::start();
+        Config::set('laratrust.middleware.handling', 'redirect');
+        Config::set('laratrust.middleware.handlers.redirect.message.content', 'The message was flashed');
+        $user = m::mock('Laratrust\Tests\Models\User')->makePartial();
+        $middleware = new LaratrustPermission($this->guard);
+
+        /*
+        |------------------------------------------------------------
+        | Expectation
+        |------------------------------------------------------------
+        */
+        Auth::shouldReceive('guard')->with(m::anyOf('web', 'api'))->andReturn($this->guard);
+        $this->guard->shouldReceive('guest')->andReturn(false);
+        $this->guard->shouldReceive('user')->andReturn($user);
+        $user->shouldReceive('hasPermission')
+            ->with(
+                ['users-create', 'users-update'],
+                m::anyOf(null, 'TeamA'),
+                m::anyOf(true, false)
+            )
+            ->andReturn(false);
+
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'guard:api'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'require_all'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'guard:api|require_all'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'TeamA', 'require_all'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'TeamA', 'guard:api|require_all'));
+
+        $this->assertArrayHasKey('error', session()->all());
+        $this->assertContains('message', session()->get('error'));
+    }
+
+    public function testHandle_IsLoggedInWithNoPermission_ShouldWithoutError()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        Session::start();
+        $user = m::mock('Laratrust\Tests\Models\User')->makePartial();
+        $middleware = new LaratrustPermission($this->guard);
+        Config::set('laratrust.middleware.handling','redirect');
+
+        /*
+        |------------------------------------------------------------
+        | Expectation
+        |------------------------------------------------------------
+        */
+        Auth::shouldReceive('guard')->with(m::anyOf('web', 'api'))->andReturn($this->guard);
+        $this->guard->shouldReceive('guest')->andReturn(false);
+        $this->guard->shouldReceive('user')->andReturn($user);
+        $user->shouldReceive('hasPermission')
+            ->with(
+                ['users-create', 'users-update'],
+                m::anyOf(null, 'TeamA'),
+                m::anyOf(true, false)
+            )
+            ->andReturn(false);
+
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'guard:api'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'require_all'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'guard:api|require_all'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'TeamA', 'require_all'));
+
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'users-create|users-update', 'TeamA', 'guard:api|require_all'));
+
+        $this->assertArrayNotHasKey('error', session()->all());
     }
 }

--- a/tests/Middleware/LaratrustRoleTest.php
+++ b/tests/Middleware/LaratrustRoleTest.php
@@ -2,6 +2,8 @@
 
 namespace Laratrust\Tests\Middleware;
 
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Session;
 use Mockery as m;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
@@ -135,5 +137,151 @@ class LaratrustRoleTest extends MiddlewareTest
 
         $this->assertNull($middleware->handle($this->request, function () {
         }, 'admin|user', 'TeamA', 'require_all|guard:api'));
+    }
+
+    public function testHandle_IsLoggedInWithMismatchRole_ShouldRedirectWithoutError()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        Session::start();
+        Config::set('laratrust.middleware.handling', 'redirect');
+        $user = m::mock('Laratrust\Tests\Models\User')->makePartial();
+        $middleware = new LaratrustRole($this->guard);
+
+
+        /*
+        |------------------------------------------------------------
+        | Expectation
+        |------------------------------------------------------------
+        */
+        $this->guard->shouldReceive('guest')->andReturn(false);
+        Auth::shouldReceive('guard')->with(m::anyOf('web', 'api'))->andReturn($this->guard);
+        $this->guard->shouldReceive('user')->andReturn($user);
+        $user->shouldReceive('hasRole')
+            ->with(
+                ['admin', 'user'],
+                m::anyOf(null, 'TeamA'),
+                m::anyOf(true, false)
+            )
+            ->andReturn(false);
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'guard:api'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'guard:api'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'require_all'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'require_all'));
+
+        $this->assertObjectHasAttribute('content',$middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'guard:api|require_all'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'guard:api|require_all'));
+
+        $this->assertArrayNotHasKey('error', session()->all());
+
+    }
+
+    public function testHandle_IsLoggedInWithMismatchRole_ShouldRedirectWithError()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        Session::start();
+        Config::set('laratrust.middleware.handling', 'redirect');
+        Config::set('laratrust.middleware.handlers.redirect.message.content', 'The message was flashed');
+        $user = m::mock('Laratrust\Tests\Models\User')->makePartial();
+        $middleware = new LaratrustRole($this->guard);
+
+
+        /*
+        |------------------------------------------------------------
+        | Expectation
+        |------------------------------------------------------------
+        */
+        $this->guard->shouldReceive('guest')->andReturn(false);
+        Auth::shouldReceive('guard')->with(m::anyOf('web', 'api'))->andReturn($this->guard);
+        $this->guard->shouldReceive('user')->andReturn($user);
+        $user->shouldReceive('hasRole')
+            ->with(
+                ['admin', 'user'],
+                m::anyOf(null, 'TeamA'),
+                m::anyOf(true, false)
+            )
+            ->andReturn(false);
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'guard:api'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'guard:api'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'require_all|guard:api'));
+
+        $this->assertObjectHasAttribute('content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'require_all'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'require_all'));
+
+        $this->assertObjectHasAttribute('content',$middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'guard:api|require_all'));
+        $this->assertAttributeContains('/home', 'content', $middleware->handle($this->request, function () {
+        }, 'admin|user', 'TeamA', 'guard:api|require_all'));
+
+        $this->assertArrayHasKey('error', session()->all());
+        $this->assertContains('message', session()->get('error'));
+
     }
 }


### PR DESCRIPTION
Allow people the option to flash error messages when the middleware redirects them.