### PR TITLE
Laravel 5.8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "~5.2.32|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0",
+        "laravel/framework": "~5.2.32|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "kkszymanowski/traitor": "^0.2.0"
     },
     "require-dev": {
         "mockery/mockery": ">=0.9.9",
         "phpunit/phpunit": ">=4.1",
-        "orchestra/testbench": "~3.2.0|~3.3.0|~3.4.6|~3.5.0|~3.6.0|~3.7.0"
+        "orchestra/testbench": "~3.2.0|~3.3.0|~3.4.6|~3.5.0|~3.6.0|~3.7.0|~3.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Traits/LaratrustHasEvents.php
+++ b/src/Traits/LaratrustHasEvents.php
@@ -43,7 +43,7 @@ trait LaratrustHasEvents
             return true;
         }
 
-        return static::$dispatcher->fire(
+        return static::$dispatcher->dispatch(
             "laratrust.{$event}: ".static::class,
             $payload
         );

--- a/tests/Checkers/Role/LaratrustRoleDefaultCheckerCacheTest.php
+++ b/tests/Checkers/Role/LaratrustRoleDefaultCheckerCacheTest.php
@@ -9,7 +9,7 @@ use Laratrust\Tests\Models\Permission;
 
 class LaratrustRoleDefaultCheckerCacheTest extends LaratrustTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/Role/LaratrustRoleDefaultCheckerTest.php
+++ b/tests/Checkers/Role/LaratrustRoleDefaultCheckerTest.php
@@ -10,7 +10,7 @@ class LaratrustRoleDefaultCheckerTest extends LaratrustTestCase
 {
     protected $role;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/Role/LaratrustRoleQueryCheckerTest.php
+++ b/tests/Checkers/Role/LaratrustRoleQueryCheckerTest.php
@@ -10,7 +10,7 @@ class LaratrustRoleQueryCheckerTest extends LaratrustTestCase
 {
     protected $role;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/User/LaratrustUserAbilityCheckerTestCase.php
+++ b/tests/Checkers/User/LaratrustUserAbilityCheckerTestCase.php
@@ -12,7 +12,7 @@ class LaratrustUserAbilityCheckerTestCase extends LaratrustTestCase
 {
     protected $user;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/User/LaratrustUserAbilityDefaultCheckerTest.php
+++ b/tests/Checkers/User/LaratrustUserAbilityDefaultCheckerTest.php
@@ -4,7 +4,7 @@ namespace Laratrust\Tests\Checkers\User;
 
 class LaratrustUserAbilityDefaultCheckerTest extends LaratrustUserAbilityCheckerTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/User/LaratrustUserAbilityQueryCheckerTest.php
+++ b/tests/Checkers/User/LaratrustUserAbilityQueryCheckerTest.php
@@ -4,7 +4,7 @@ namespace Laratrust\Tests\Checkers\User;
 
 class LaratrustUserAbilityQueryCheckerTest extends LaratrustUserAbilityCheckerTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/User/LaratrustUserCheckerTestCase.php
+++ b/tests/Checkers/User/LaratrustUserCheckerTestCase.php
@@ -13,7 +13,7 @@ class LaratrustUserCheckerTestCase extends LaratrustTestCase
 {
     protected $user;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/User/LaratrustUserDefaultCheckerTest.php
+++ b/tests/Checkers/User/LaratrustUserDefaultCheckerTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Config;
 
 class LaratrustUserDefaultCheckerTest extends LaratrustUserCheckerTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Checkers/User/LaratrustUserQueryCheckerTest.php
+++ b/tests/Checkers/User/LaratrustUserQueryCheckerTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Config;
 
 class LaratrustUserQueryCheckerTest extends LaratrustUserCheckerTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/LaratrustEventsTestCase.php
+++ b/tests/LaratrustEventsTestCase.php
@@ -45,7 +45,7 @@ class LaratrustEventsTestCase extends LaratrustTestCase
 
         $this->assertTrue($dispatcher->hasListeners($eventName));
         $this->assertCount(1, $dispatcher->getListeners($eventName));
-        $this->assertEquals('test', $dispatcher->fire($eventName, ['user', 'an_id', null])[0]);
+        $this->assertEquals('test', $dispatcher->dispatch($eventName, ['user', 'an_id', null])[0]);
     }
 
     /**
@@ -58,7 +58,7 @@ class LaratrustEventsTestCase extends LaratrustTestCase
      */
     protected function dispatcherShouldFire($event, array $payload, $modelClass)
     {
-        $this->dispatcher->shouldReceive('fire')
+        $this->dispatcher->shouldReceive('dispatch')
             ->with(
                 "laratrust.{$event}: {$modelClass}",
                 $payload

--- a/tests/LaratrustEventsTestCase.php
+++ b/tests/LaratrustEventsTestCase.php
@@ -8,7 +8,7 @@ class LaratrustEventsTestCase extends LaratrustTestCase
 {
     protected $dispatcher;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/LaratrustPermissionTest.php
+++ b/tests/LaratrustPermissionTest.php
@@ -9,7 +9,7 @@ class LaratrustPermissionTest extends LaratrustTestCase
 {
     protected $permission;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/LaratrustRoleEventsTest.php
+++ b/tests/LaratrustRoleEventsTest.php
@@ -9,7 +9,7 @@ class LaratrustRoleEventsTest extends LaratrustEventsTestCase
 {
     protected $role;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->role = Role::create(['name' => 'role']);

--- a/tests/LaratrustRoleTest.php
+++ b/tests/LaratrustRoleTest.php
@@ -10,7 +10,7 @@ class LaratrustRoleTest extends LaratrustTestCase
 {
     protected $role;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/LaratrustTest.php
+++ b/tests/LaratrustTest.php
@@ -9,7 +9,7 @@ class LaratrustTest extends LaratrustTestCase
     protected $laratrust;
     protected $user;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->laratrust = m::mock('Laratrust\Laratrust[user]', [$this->app]);

--- a/tests/LaratrustUserEventsTest.php
+++ b/tests/LaratrustUserEventsTest.php
@@ -10,7 +10,7 @@ class LaratrustUserEventsTest extends LaratrustEventsTestCase
 {
     protected $user;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/LaratrustUserScopesTest.php
+++ b/tests/LaratrustUserScopesTest.php
@@ -12,7 +12,7 @@ class LaratrustUserScopesTest extends LaratrustTestCase
 {
     protected $user;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/LaratrustUserTest.php
+++ b/tests/LaratrustUserTest.php
@@ -15,7 +15,7 @@ class LaratrustUserTest extends LaratrustTestCase
 {
     protected $user;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Middleware/MiddlewareTest.php
+++ b/tests/Middleware/MiddlewareTest.php
@@ -10,7 +10,7 @@ abstract class MiddlewareTest extends LaratrustTestCase
     protected $request;
     protected $guard;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->request = m::mock('Illuminate\Http\Request');


### PR DESCRIPTION
There are few breaking changes in the newest Laravel Release.

- `fire` method was deprecated in Laravel 5.4 and is now removed in Laravel 5.8. Replaced it with the `dispatch` method.
- PHPUnit upgrade `setUp` method now uses php 7.1 type hints and the same were implemented by the `orchestra/testbench` package. So all test cases need to be compatible with the `setUp` method.
