### PR TITLE
updated allPermissions() method

### DIFF
--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -590,7 +590,7 @@ trait LaratrustUserTrait
             return $role->permissions;
         });
 
-        return $this->permissions->merge($roles)->unique('name');
+        return $this->permissions()->get()->merge($roles)->unique('name');
     }
 
     /**


### PR DESCRIPTION
To avoid `->merge($roles)`  **`ON NULL`**, return a `get()` instead which will be an *empty* collection, then proceed with `->merge($roles)`.