### PR TITLE
Updated LaratrustUserTrait.php PHPDocs

### DIFF
--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -12,6 +12,7 @@ namespace Laratrust\Traits;
 use Laratrust\Helper;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Laratrust\Checkers\LaratrustCheckerManager;
@@ -580,7 +581,7 @@ trait LaratrustUserTrait
     /**
      * Return all the user permissions.
      *
-     * @return boolean
+     * @return Collection
      */
     public function allPermissions()
     {

--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -12,7 +12,6 @@ namespace Laratrust\Traits;
 use Laratrust\Helper;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Laratrust\Checkers\LaratrustCheckerManager;
@@ -581,7 +580,7 @@ trait LaratrustUserTrait
     /**
      * Return all the user permissions.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection|static
      */
     public function allPermissions()
     {


### PR DESCRIPTION
The LaratrustUserTrait::allPermissions() method returns a Collection, but in its PHPDoc it returns boolean, and it causes problems when our static checker is run in CI/CD. I fixed that return type.