### PR TITLE
Added laravel 6.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": "^7.1",
         "kkszymanowski/traitor": "^0.2.0",
-        "laravel/framework": "~6.0"
+        "laravel/framework": "~5.6.0|~5.7.0|~5.8.0|~6.0"
     },
     "require-dev": {
         "mockery/mockery": ">=0.9.9",
-        "orchestra/testbench": "~3.9.0",
+        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|~3.9.0",
         "phpunit/phpunit": ">=4.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "laravel/framework": "~5.6.0|~5.7.0|~5.8.0",
-        "kkszymanowski/traitor": "^0.2.0"
+        "kkszymanowski/traitor": "^0.2.0",
+        "laravel/framework": "~6.0"
     },
     "require-dev": {
         "mockery/mockery": ">=0.9.9",
-        "phpunit/phpunit": ">=4.1",
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0"
+        "orchestra/testbench": "~3.9.0",
+        "phpunit/phpunit": ">=4.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Checkers/Role/LaratrustRoleDefaultChecker.php
+++ b/src/Checkers/Role/LaratrustRoleDefaultChecker.php
@@ -2,6 +2,7 @@
 
 namespace Laratrust\Checkers\Role;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 
@@ -38,7 +39,7 @@ class LaratrustRoleDefaultChecker extends LaratrustRoleChecker
         }
 
         foreach ($this->currentRoleCachedPermissions() as $perm) {
-            if (str_is($permission, $perm['name'])) {
+            if (Str::is($permission, $perm['name'])) {
                 return true;
             }
         }

--- a/src/Checkers/User/LaratrustUserDefaultChecker.php
+++ b/src/Checkers/User/LaratrustUserDefaultChecker.php
@@ -2,6 +2,7 @@
 
 namespace Laratrust\Checkers\User;
 
+use Illuminate\Support\Str;
 use Laratrust\Helper;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
@@ -90,7 +91,7 @@ class LaratrustUserDefaultChecker extends LaratrustUserChecker
         $team = Helper::fetchTeam($team);
 
         foreach ($this->userCachedPermissions() as $perm) {
-            if (Helper::isInSameTeam($perm, $team) && str_is($permission, $perm['name'])) {
+            if (Helper::isInSameTeam($perm, $team) && Str::is($permission, $perm['name'])) {
                 return true;
             }
         }

--- a/tests/LaratrustUserTest.php
+++ b/tests/LaratrustUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Laratrust\Test;
 
+use Illuminate\Support\Str;
 use Mockery as m;
 use Laratrust\Tests\Models\Role;
 use Laratrust\Tests\Models\Team;
@@ -567,7 +568,7 @@ class LaratrustUserTest extends LaratrustTestCase
         |------------------------------------------------------------
         */
         $user = m::mock('Laratrust\Tests\Models\User')->makePartial();
-        $className = snake_case(get_class($user)) . '_id';
+        $className = Str::snake(get_class($user)) . '_id';
 
         $post = new \stdClass();
         $post->$className = $user->getKey();


### PR DESCRIPTION
Updated the following files because they use functions that were removed in laravel 6.0:
- src/Checkers/Role/LaratrustRoleDefaultChecker.php
- src/Checkers/User/LaratrustUserDefaultChecker.php
- tests/LaratrustUserTest.php

The test in travis for php 7.1 fails because laravel 6.0 doesn't support's only 7.2 and higher.