### PR TITLE
Provide option to allow the response text when using abort handler

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -233,10 +233,11 @@ return [
          */
         'handlers' => [
             /**
-             * Aborts the execution with a 403 code.
+             * Aborts the execution with a 403 code and allows you to provide the response text
              */
             'abort' => [
-                'code' => 403
+                'code' => 403,
+                'message' => 'User does not have any of the necessary access rights.'
             ],
             /**
              * Redirects the user to the given url.

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -46,7 +46,7 @@ class LaratrustMiddleware
         $handler = Config::get("laratrust.middleware.handlers.{$handling}");
 
         if ($handling == 'abort') {
-            return App::abort($handler['code']);
+            return App::abort($handler['code'], $handler['message']);
         }
 
         $redirect = Redirect::to($handler['url']);

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -46,7 +46,7 @@ class LaratrustMiddleware
         $handler = Config::get("laratrust.middleware.handlers.{$handling}");
 
         if ($handling == 'abort') {
-            return App::abort($handler['code'], $handler['message']);
+            return App::abort($handler['code'], $handler['message'] ?? '');
         }
 
         $redirect = Redirect::to($handler['url']);


### PR DESCRIPTION
Hello, just wanted the ability to pass a message string for middleware error handling. If value is null it will still work as before but this way it allows us to customize the abort() call.