### PR TITLE
Method to get (cached) roles of user

### DIFF
--- a/docs/docs/5.0/usage/concepts.md
+++ b/docs/docs/5.0/usage/concepts.md
@@ -324,6 +324,18 @@ dump($user->allPermissions());
 */
 ```
 
+If you want to retrieve all the user roles, you can use the `getRoles` method. It returns an array with the names of the roles. If you enabled the Laratrust cache, then those roles will be retrieved from the cache instead of running database queries.
+
+```php
+dump($user->getRoles());
+/*
+    array:3 [
+        0 => "User Administrator"
+        1 => "Project Owner"
+    ]
+*/
+```
+
 If you want to retrieve the users that have some role you can use the query scope `whereRoleIs`:
 
 ```php
@@ -576,4 +588,21 @@ $options = [
 $post = Post::find(1);
 $user->canAndOwns(['edit-post', 'delete-post'], $post, $options);
 $user->hasRoleAndOwns(['admin', 'writer'], $post, $options);
+```
+
+### Retrieving Relationships
+
+To get the roles is the same, but this time you can pass the team parameter. The returned roles are determined by changing `teams_strict_check` value inside the `config/laratrust.php` file.
+
+- If `teams_strict_check` is set to `false`:
+    When `getRoles` method is call without a team, it will return both the user roles where team id is null and not null.
+
+- If `teams_strict_check` is set to `true`:
+    When `getRoles` method is call without a team, it will return if the user roles where the team id is null.
+
+Get roles:
+
+```php
+    $user->getRoles();
+    $user->getRoles('my-awesome-team');
 ```

--- a/src/Checkers/User/LaratrustUserDefaultChecker.php
+++ b/src/Checkers/User/LaratrustUserDefaultChecker.php
@@ -12,6 +12,33 @@ class LaratrustUserDefaultChecker extends LaratrustUserChecker
     /**
      * Checks if the user has a role by its name.
      *
+     * @param  string|bool   $team      Team name.
+     * @return array
+     */
+    public function getCurrentUserRoles($team = null)
+    {
+        $roles = collect($this->userCachedRoles());
+
+        if (config('laratrust.use_teams') === false || config('laratrust.teams_strict_check') === false) {
+            return $roles->pluck('name')->toArray();
+        }
+
+        if ($team !== null) {
+            $team = Helper::fetchTeam($team);
+
+            return $roles->filter(function ($role) use ($team) {
+                return $role[config('laratrust.foreign_keys.team')] === $team->id;
+            });
+        }
+
+        return $roles->filter(function ($role) use ($team) {
+            return $role[config('laratrust.foreign_keys.team')] === null;
+        });
+    }
+
+    /**
+     * Checks if the user has a role by its name.
+     *
      * @param  string|array  $name       Role name or array of role names.
      * @param  string|bool   $team      Team name or requiredAll roles.
      * @param  bool          $requireAll All roles in the array are required.

--- a/src/Checkers/User/LaratrustUserDefaultChecker.php
+++ b/src/Checkers/User/LaratrustUserDefaultChecker.php
@@ -19,21 +19,25 @@ class LaratrustUserDefaultChecker extends LaratrustUserChecker
     {
         $roles = collect($this->userCachedRoles());
 
-        if (config('laratrust.use_teams') === false || config('laratrust.teams_strict_check') === false) {
+        if (config('laratrust.use_teams') === false) {
             return $roles->pluck('name')->toArray();
         }
 
-        if ($team !== null) {
-            $team = Helper::fetchTeam($team);
-
-            return $roles->filter(function ($role) use ($team) {
-                return $role[config('laratrust.foreign_keys.team')] === $team->id;
-            });
+        if ($team === null && config('laratrust.teams_strict_check') === false) {
+            return $roles->pluck('name')->toArray();
         }
 
-        return $roles->filter(function ($role) use ($team) {
-            return $role[config('laratrust.foreign_keys.team')] === null;
-        });
+        if ($team === null) {
+            return $roles->filter(function ($role) {
+                return $role['pivot'][config('laratrust.foreign_keys.team')] === null;
+            })->pluck('name')->toArray();
+        }
+
+        $teamId = Helper::fetchTeam($team);
+
+        return $roles->filter(function ($role) use ($teamId) {
+            return $role['pivot'][config('laratrust.foreign_keys.team')] == $teamId;
+        })->pluck('name')->toArray();
     }
 
     /**

--- a/src/Checkers/User/LaratrustUserQueryChecker.php
+++ b/src/Checkers/User/LaratrustUserQueryChecker.php
@@ -10,6 +10,35 @@ class LaratrustUserQueryChecker extends LaratrustUserChecker
     /**
      * Checks if the user has a role by its name.
      *
+     * @param  string|bool   $team      Team name.
+     * @return array
+     */
+    public function getCurrentUserRoles($team = null)
+    {
+        if (config('laratrust.use_teams') === false || config('laratrust.teams_strict_check') === false) {
+            return $this->user->roles->pluck('name')->toArray();
+        }
+
+        if ($team !== null) {
+            $team = Helper::fetchTeam($team);
+
+            return $this->user
+                ->roles()
+                ->where(config('laratrust.foreign_keys.team'), $team->id)
+                ->pluck('name')
+                ->toArray();
+        }
+
+        return $this->user
+            ->roles()
+            ->where(config('laratrust.foreign_keys.team'), null)
+            ->pluck('name')
+            ->toArray();
+    }
+
+    /**
+     * Checks if the user has a role by its name.
+     *
      * @param  string|array  $name       Role name or array of role names.
      * @param  string|bool   $team      Team name or requiredAll roles.
      * @param  bool          $requireAll All roles in the array are required.

--- a/src/Checkers/User/LaratrustUserQueryChecker.php
+++ b/src/Checkers/User/LaratrustUserQueryChecker.php
@@ -15,23 +15,27 @@ class LaratrustUserQueryChecker extends LaratrustUserChecker
      */
     public function getCurrentUserRoles($team = null)
     {
-        if (config('laratrust.use_teams') === false || config('laratrust.teams_strict_check') === false) {
+        if (config('laratrust.use_teams') === false) {
             return $this->user->roles->pluck('name')->toArray();
         }
 
-        if ($team !== null) {
-            $team = Helper::fetchTeam($team);
+        if ($team === null && config('laratrust.teams_strict_check') === false) {
+            return $this->user->roles->pluck('name')->toArray();
+        }
 
+        if ($team === null) {
             return $this->user
                 ->roles()
-                ->where(config('laratrust.foreign_keys.team'), $team->id)
+                ->wherePivot(config('laratrust.foreign_keys.team'), null)
                 ->pluck('name')
                 ->toArray();
         }
 
+        $teamId = Helper::fetchTeam($team);
+
         return $this->user
             ->roles()
-            ->where(config('laratrust.foreign_keys.team'), null)
+            ->wherePivot(config('laratrust.foreign_keys.team'), $teamId)
             ->pluck('name')
             ->toArray();
     }

--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -128,6 +128,17 @@ trait LaratrustUserTrait
     }
 
     /**
+     * Get the the names of the user's roles.
+     *
+     * @param  string|bool   $team      Team name.
+     * @return bool
+     */
+    public function getRoles($team = null)
+    {
+        return $this->laratrustUserChecker()->getCurrentUserRoles($team);
+    }
+
+    /**
      * Checks if the user has a role by its name.
      *
      * @param  string|array  $name       Role name or array of role names.

--- a/tests/Checkers/User/LaratrustUserCheckerTestCase.php
+++ b/tests/Checkers/User/LaratrustUserCheckerTestCase.php
@@ -23,6 +23,42 @@ class LaratrustUserCheckerTestCase extends LaratrustTestCase
         $this->app['config']->set('laratrust.use_teams', true);
     }
 
+    protected function getRolesAssertions()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        $team = Team::create(['name' => 'team_a']);
+        $roles = [
+            Role::create(['name' => 'role_a'])->id => ['team_id' => null],
+            Role::create(['name' => 'role_b'])->id => ['team_id' => null],
+            Role::create(['name' => 'role_c'])->id => ['team_id' => $team->id ]
+        ];
+        $this->app['config']->set('laratrust.use_teams', true);
+        $this->user->roles()->attach($roles);
+
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->app['config']->set('laratrust.teams_strict_check', true);
+        $this->assertEquals(['role_a', 'role_b'], $this->user->getRoles());
+        $this->app['config']->set('laratrust.teams_strict_check', false);
+        $this->assertEquals(['role_a', 'role_b', 'role_c'], $this->user->getRoles());
+
+        $this->app['config']->set('laratrust.teams_strict_check', true);
+        $this->assertEquals(['role_c'], $this->user->getRoles('team_a'));
+        $this->app['config']->set('laratrust.teams_strict_check', false);
+        $this->assertEquals(['role_c'], $this->user->getRoles('team_a'));
+
+        $this->app['config']->set('laratrust.cache.enabled', false);
+        $this->assertEquals(['role_a', 'role_b', 'role_c'], $this->user->getRoles());
+        $this->assertEquals(['role_c'], $this->user->getRoles('team_a'));
+    }
+
     protected function hasRoleAssertions()
     {
         /*

--- a/tests/Checkers/User/LaratrustUserDefaultCheckerTest.php
+++ b/tests/Checkers/User/LaratrustUserDefaultCheckerTest.php
@@ -13,6 +13,11 @@ class LaratrustUserDefaultCheckerTest extends LaratrustUserCheckerTestCase
         $this->app['config']->set('laratrust.checker', 'default');
     }
 
+    public function testGetRoles()
+    {
+        $this->getRolesAssertions();
+    }
+
     public function testHasRole()
     {
         $this->hasRoleAssertions();

--- a/tests/Checkers/User/LaratrustUserQueryCheckerTest.php
+++ b/tests/Checkers/User/LaratrustUserQueryCheckerTest.php
@@ -13,6 +13,11 @@ class LaratrustUserQueryCheckerTest extends LaratrustUserCheckerTestCase
         $this->app['config']->set('laratrust.checker', 'query');
     }
 
+    public function testGetRoles()
+    {
+        $this->getRolesAssertions();
+    }
+
     public function testHasRole()
     {
         $this->hasRoleAssertions();


### PR DESCRIPTION
Fixes #375 .

This PR adds a `getRoles` method, which returns an array of roles. If you use the laratrust cache, then it will retrieve the user's roles from the cache instead of querying the database.
