### PR TITLE
Add Team Table Rollback To Team Setup

### DIFF
--- a/views/setup-teams.blade.php
+++ b/views/setup-teams.blade.php
@@ -64,5 +64,14 @@ class LaratrustSetupTeams extends Migration
      */
     public function down()
     {
+        Schema::table('{{ $laratrust['tables']['role_user'] }}', function (Blueprint $table) {
+            $table->dropForeign(['{{ $laratrust['foreign_keys']['team'] }}']);
+        });
+
+        Schema::table('{{ $laratrust['tables']['permission_user'] }}', function (Blueprint $table) {
+            $table->dropForeign(['{{ $laratrust['foreign_keys']['team'] }}']);
+        });
+
+        Schema::dropIfExists('{{ $laratrust['tables']['teams'] }}');
     }
 }


### PR DESCRIPTION
Added team rollback to `setup-teams.blade.php`

When setting up teams manually (not during main installation) following instructions here: https://laratrust.santigarcor.me/docs/5.2/configuration/teams.html; doing a rollback does not remove the Team table. 

As the migration is created after the initial setup `migration.blade.php`, we also needed to remove the foreign keys.