### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1",
         "kkszymanowski/traitor": "^0.2.0",
-        "laravel/framework": "~5.6.0|~5.7.0|~5.8.0|~6.0"
+        "laravel/framework": "~5.6.0|~5.7.0|~5.8.0|~6.0|~7.0"
     },
     "require-dev": {
         "mockery/mockery": ">=0.9.9",


### PR DESCRIPTION
- Bump supported version of Laravel to `~7.0`