### PR TITLE
Fix syncRoles when syncing without team-model

### DIFF
--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -350,7 +350,7 @@ trait LaratrustUserTrait
 
         $relationshipToSync = $this->$relationship();
 
-        if ($useTeams && $team) {
+        if ($useTeams) {
             $relationshipToSync->wherePivot(Helper::teamForeignKey(), $team);
         }
 

--- a/tests/LaratrustUserTest.php
+++ b/tests/LaratrustUserTest.php
@@ -318,6 +318,8 @@ class LaratrustUserTest extends LaratrustTestCase
         $this->assertEquals(2, $this->user->roles()->count());
         $this->assertInstanceOf('Laratrust\Tests\Models\User', $this->user->syncRoles($roles, 'team_a'));
         $this->assertEquals(4, $this->user->roles()->count());
+        $this->assertInstanceOf('Laratrust\Tests\Models\User', $this->user->syncRoles(['role_a']));
+        $this->assertEquals(3, $this->user->roles()->count());
 
         $this->app['config']->set('laratrust.use_teams', false);
         $this->user->syncRoles([]);


### PR DESCRIPTION
Imagine you have a user that has global `Role A` (outside a team) and has `Role B` in `Team 1`. 
```php
$user->syncRoles(['role_a']);
$user->syncRoles(['role_b'], 'team_1);
```
You want to update the user's global `Role A` to `Role C`, without changing its team role.
```php
$user->syncRoles(['role_c']);
```
Currently, syncRoles will also remove the `Role B` in `Team 1`.

This PR fixes this issue.

According to the [docs](https://laratrust.santigarcor.me/docs/5.2/usage/concepts.html#roles-assignment-removal), this is also the expected behavior:
> It will sync the roles depending on the team passed, because there is a wherePivot constraint in the syncing method. So if you pass a team with id of 1, it will sync all the roles that are attached to the user where the team id is 1.
> 
> So **if you don't pass any team, it will sync the roles where the team id is null** in the pivot table.

The `attachModel` and `detachModel` methods in `LaratrustUserTrait` trait work the same way.