### PR TITLE
Improved seeder for Laravel v8

### DIFF
--- a/src/Console/MakeSeederCommand.php
+++ b/src/Console/MakeSeederCommand.php
@@ -2,11 +2,12 @@
 
 namespace Laratrust\Console;
 
-use Illuminate\Console\Command;
+use Exception;
+use Illuminate\Database\Console\Seeds\SeederMakeCommand as LaravelMakeSeederCommand;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 
-class MakeSeederCommand extends Command
+class MakeSeederCommand extends LaravelMakeSeederCommand
 {
     /**
      * The console command name.
@@ -37,12 +38,21 @@ class MakeSeederCommand extends Command
             return;
         }
 
-        if ($this->createSeeder()) {
+        try {
+            $seederClass = $this->createSeederClass();
+            $this->files->put($this->seederPath(), $seederClass);
             $this->info("Seeder successfully created!");
-        } else {
+
+        } catch (Exception $exception) {
+
+            $folder = $this->files->dirname($this->seederPath());
+            $where = substr($folder, strpos($folder, 'database'));
+
+            $this->composer->dumpAutoloads();
+
             $this->error(
                 "Couldn't create seeder.\n".
-                "Check the write permissions within the database/seeds directory."
+                "Check the write permissions within the $where directory."
             );
         }
 
@@ -52,34 +62,87 @@ class MakeSeederCommand extends Command
     /**
      * Create the seeder
      *
-     * @return bool
+     * @return string
      */
-    protected function createSeeder()
+    protected function createSeederClass(): string
     {
-        $permission = Config::get('laratrust.models.permission', 'App\Permission');
+        $stub = $this->files->get($this->getStub());
+
+        $this->replaceModelClassNames($stub);
+        $this->replaceTableNames($stub);
+
+        return $stub;
+    }
+
+    /**
+     * Replace the models class names in the stub.
+     * @param  string  $stub
+     */
+    protected function replaceModelClassNames(string & $stub)
+    {
         $role = Config::get('laratrust.models.role', 'App\Role');
-        $rolePermissions = Config::get('laratrust.tables.permission_role');
-        $roleUsers = Config::get('laratrust.tables.role_user');
+        $this->replaceStubParameter($stub, 'roleConfiguredModelClass', '\\' . ltrim($role, '\\'));
+
+        $permission = Config::get('laratrust.models.permission', 'App\Permission');
+        $this->replaceStubParameter($stub, 'permissionConfiguredModelClass', '\\' . ltrim($permission, '\\'));
+   
         $user = new Collection(Config::get('laratrust.user_models', ['App\User']));
         $user = $user->first();
+        $this->replaceStubParameter($stub, 'userConfiguredModelClass', '\\' . ltrim($user, '\\'));
+    }
 
-        $output = $this->laravel->view->make('laratrust::seeder')
-            ->with(compact([
-                'role',
-                'permission',
-                'user',
-                'rolePermissions',
-                'roleUsers',
-            ]))
-            ->render();
+    /**
+     * Replace the table names in the stub.
+     * @param  string  $stub
+     */
+    protected function replaceTableNames(string & $stub)
+    {
+        $rolePermission = Config::get('laratrust.tables.permission_role');
+        $this->replaceStubParameter($stub, 'permission_roleConfiguredTableName', $rolePermission);
 
-        if ($fs = fopen($this->seederPath(), 'x')) {
-            fwrite($fs, $output);
-            fclose($fs);
-            return true;
-        }
+        $permissionUser = Config::get('laratrust.tables.permission_user');
+        $this->replaceStubParameter($stub, 'permission_userConfiguredTableName', $permissionUser);
 
-        return false;
+        $roleUser = Config::get('laratrust.tables.role_user');
+        $this->replaceStubParameter($stub, 'role_userConfiguredTableName', $roleUser);
+
+        $rolesTable = Config::get('laratrust.tables.roles');
+        $this->replaceStubParameter($stub, 'rolesTableName', $rolesTable);
+
+        $permissionsTable = Config::get('laratrust.tables.permissions');
+        $this->replaceStubParameter($stub, 'permissionsTableName', $permissionsTable);
+    }
+
+    /**
+     * Replace a placeholder parameter in the stub.
+     * @param  string  $stub
+     * @param  string  $parameter
+     * @param  string  $value
+     */
+    protected function replaceStubParameter(string & $stub, string $parameter, string $value)
+    {
+        $stub = str_replace('{{'.$parameter.'}}', $value, $stub);
+    }
+
+    /**
+     * Get the seeder stub file.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/seeder.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return __DIR__."/../../$stub";
     }
 
     /**
@@ -89,6 +152,17 @@ class MakeSeederCommand extends Command
      */
     protected function seederPath()
     {
-        return database_path("seeders/LaratrustSeeder.php");
+        return $this->getPath('LaratrustSeeder');
     }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
 }

--- a/src/Console/MakeSeederCommand.php
+++ b/src/Console/MakeSeederCommand.php
@@ -48,8 +48,6 @@ class MakeSeederCommand extends LaravelMakeSeederCommand
             $folder = $this->files->dirname($this->seederPath());
             $where = substr($folder, strpos($folder, 'database'));
 
-            $this->composer->dumpAutoloads();
-
             $this->error(
                 "Couldn't create seeder.\n".
                 "Check the write permissions within the $where directory."
@@ -68,10 +66,26 @@ class MakeSeederCommand extends LaravelMakeSeederCommand
     {
         $stub = $this->files->get($this->getStub());
 
+        $this->replaceSeederNamespace($stub);
         $this->replaceModelClassNames($stub);
         $this->replaceTableNames($stub);
 
         return $stub;
+    }
+
+    /**
+     * Replace the namespace of the seeder.
+     * @param  string  $stub
+     */
+    protected function replaceSeederNamespace(string & $stub)
+    {
+        $namespace = '';
+
+        if (version_compare($this->getLaravel()->version(), '8.0') >= 0) {
+            $namespace = "\nnamespace Database\Seeders;\n";
+        }
+
+        $this->replaceStubParameter($stub, 'namespace', $namespace);
     }
 
     /**

--- a/src/Console/MakeSeederCommand.php
+++ b/src/Console/MakeSeederCommand.php
@@ -3,9 +3,9 @@
 namespace Laratrust\Console;
 
 use Exception;
-use Illuminate\Database\Console\Seeds\SeederMakeCommand as LaravelMakeSeederCommand;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Database\Console\Seeds\SeederMakeCommand as LaravelMakeSeederCommand;
 
 class MakeSeederCommand extends LaravelMakeSeederCommand
 {
@@ -42,9 +42,7 @@ class MakeSeederCommand extends LaravelMakeSeederCommand
             $seederClass = $this->createSeederClass();
             $this->files->put($this->seederPath(), $seederClass);
             $this->info("Seeder successfully created!");
-
         } catch (Exception $exception) {
-
             $folder = $this->files->dirname($this->seederPath());
             $where = substr($folder, strpos($folder, 'database'));
 
@@ -178,5 +176,4 @@ class MakeSeederCommand extends LaravelMakeSeederCommand
     {
         return [];
     }
-
 }

--- a/stubs/seeder.stub
+++ b/stubs/seeder.stub
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Config;
+
+class LaratrustSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->truncateLaratrustTables();
+
+        $config = config('laratrust_seeder.roles_structure');
+        $mapPermission = collect(config('laratrust_seeder.permissions_map'));
+
+        foreach ($config as $key => $modules) {
+
+            // Create a new role
+            $role = {{roleConfiguredModelClass}}::firstOrCreate([
+                'name' => $key,
+                'display_name' => ucwords(str_replace('_', ' ', $key)),
+                'description' => ucwords(str_replace('_', ' ', $key))
+            ]);
+            $permissions = [];
+
+            $this->command->info('Creating Role '. strtoupper($key));
+
+            // Reading role permission modules
+            foreach ($modules as $module => $value) {
+
+                foreach (explode(',', $value) as $p => $perm) {
+
+                    $permissionValue = $mapPermission->get($perm);
+
+                    $permissions[] = {{permissionConfiguredModelClass}}::firstOrCreate([
+                        'name' => $module . '-' . $permissionValue,
+                        'display_name' => ucfirst($permissionValue) . ' ' . ucfirst($module),
+                        'description' => ucfirst($permissionValue) . ' ' . ucfirst($module),
+                    ])->id;
+
+                    $this->command->info('Creating Permission to '.$permissionValue.' for '. $module);
+                }
+            }
+
+            // Attach all permissions to the role
+            $role->permissions()->sync($permissions);
+
+            if(Config::get('laratrust_seeder.create_users')) {
+                $this->command->info("Creating '{$key}' user");
+                // Create default user for each role
+                $user = {{userConfiguredModelClass}}::create([
+                    'name' => ucwords(str_replace('_', ' ', $key)),
+                    'email' => $key.'@app.com',
+                    'password' => bcrypt('password')
+                ]);
+                $user->attachRole($role);
+            }
+
+        }
+    }
+
+    /**
+     * Truncates all the laratrust tables and the users table
+     *
+     * @return  void
+     */
+    public function truncateLaratrustTables()
+    {
+        $this->command->info('Truncating User, Role and Permission tables');
+        Schema::disableForeignKeyConstraints();
+
+        DB::table('{{permission_roleConfiguredTableName}}')->truncate();
+        DB::table('{{permission_userConfiguredTableName}}')->truncate();
+        DB::table('{{role_userConfiguredTableName}}')->truncate();
+
+        if (Config::get('laratrust_seeder.truncate_tables')) {
+            DB::table('{{rolesTableName}}')->truncate();
+            DB::table('{{permissionsTableName}}')->truncate();
+            
+            if (Config::get('laratrust_seeder.create_users')) {
+                $usersTable = (new {{userConfiguredModelClass}})->getTable();
+                DB::table($usersTable)->truncate();
+            }
+        }
+
+        Schema::enableForeignKeyConstraints();
+    }
+}

--- a/stubs/seeder.stub
+++ b/stubs/seeder.stub
@@ -16,7 +16,14 @@ class LaratrustSeeder extends Seeder
     {
         $this->truncateLaratrustTables();
 
-        $config = config('laratrust_seeder.roles_structure');
+        $config = Config::get('laratrust_seeder.roles_structure');
+
+        if ($config === null) {
+            $this->command->error("The configuration has not been published. Did you run `php artisan vendor:publish --tag=\"laratrust-seeder\"`");
+            $this->command->line('');
+            return false;
+        }
+
         $mapPermission = collect(config('laratrust_seeder.permissions_map'));
 
         foreach ($config as $key => $modules) {
@@ -51,7 +58,7 @@ class LaratrustSeeder extends Seeder
             // Attach all permissions to the role
             $role->permissions()->sync($permissions);
 
-            if(Config::get('laratrust_seeder.create_users')) {
+            if (Config::get('laratrust_seeder.create_users')) {
                 $this->command->info("Creating '{$key}' user");
                 // Create default user for each role
                 $user = {{userConfiguredModelClass}}::create([

--- a/stubs/seeder.stub
+++ b/stubs/seeder.stub
@@ -1,5 +1,5 @@
 <?php
-
+{{namespace}}
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;


### PR DESCRIPTION
The changes fix the new "seeders" directory and keep compatible with the old "seeds" directory by extending the Laravel Database seeder "make" command.
Implement and use a stud file instead of a view and include the newly introduced namespace in Laravel v8 in the seeder classes.
Adds a check on whether the "laratrust_seeder" config file is published while running the seeder.
Consolidates the truncating tables method in the seeder.