### PR TITLE
Add Ability to Display Roles/Permissions Being Checked in Abort Message

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -320,5 +320,16 @@ return [
             // The user won't be able to delete the role.
             'not_deletable' => [],
         ],
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Display the Roles/Permissions being checked
+    |--------------------------------------------------------------------------
+    |
+    | If true, the roles or permissions being checked will be included
+    | in the abort message.
+    |
+    */
+    'display_roles_permissions_being_checked' => true,
 ];


### PR DESCRIPTION
Sometimes there may arise a scenario where you may like to display/determine the role/permission being checked to the sys admin - who may or may not be a developer - to avoid you as the developer from constantly being asked and phoned which permission they should give to a user. Also, a developer may be too *lazy* to keep going to code to check the role/permission required for a specific task, and it would be blazing fast if the role/permission was too obvious to the eye, thereby increasing their productivity. However, this case scenario may be very unique to a project, but it would be a nice thing to have such an ability just-in-case :)

NB: The config is set to false by default.

```php
/*
    |--------------------------------------------------------------------------
    | Display the Roles/Permissions being checked
    |--------------------------------------------------------------------------
    |
    | If true, the roles or permissions being checked will be included
    | in the abort message.
    |
    */
    'display_roles_permissions_being_checked' => false,

```

