### PR TITLE
create & store for permissions on panel side

### DIFF
--- a/resources/views/panel/permissions/index.blade.php
+++ b/resources/views/panel/permissions/index.blade.php
@@ -4,8 +4,14 @@
 
 @section('content')
   <div class="flex flex-col">
+    <a
+      href="{{route('laratrust.permissions.create')}}"
+      class="self-end bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
+    >
+      + New Permission
+    </a>
     <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-      <div class="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
+      <div class="mt-4 align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
         <table class="min-w-full">
           <thead>
             <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 
 Route::resource('/permissions', 'PermissionsController', ['as' => 'laratrust'])
-    ->only(['index', 'edit', 'update']);
+    ->only(['index', 'create', 'store', 'edit', 'update']);
 
 Route::resource('/roles', 'RolesController', ['as' => 'laratrust']);
 

--- a/src/Http/Controllers/PermissionsController.php
+++ b/src/Http/Controllers/PermissionsController.php
@@ -23,6 +23,30 @@ class PermissionsController
         ]);
     }
 
+    public function create()
+    {
+        return View::make('laratrust::panel.edit', [
+            'model' => null,
+            'permissions' => null,
+            'type' => 'permission',
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:roles,name',
+            'display_name' => 'nullable|string',
+            'description' => 'nullable|string',
+        ]);
+
+        $permission = $this->permissionModel::create($data);
+        
+
+        Session::flash('laratrust-success', 'Permission created successfully');
+        return redirect(route('laratrust.permissions.index'));
+    }
+
     public function edit($id)
     {
         $permission = $this->permissionModel::findOrFail($id);


### PR DESCRIPTION
While working on a project I found that creating permissions was not possible via administration panel.
This pull request does the same.