### PR TITLE
Fix no query result when checking is ableTo with an UUID team id

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -26,10 +26,12 @@ class Helper
             return $object['id'];
         } elseif (is_numeric($object)) {
             return $object;
-        } elseif (is_string($object)) {
+        } elseif (is_string($object) && $type !== 'team') {
             return call_user_func_array([
                 Config::get("laratrust.models.{$type}"), 'where'
             ], ['name', $object])->firstOrFail()->getKey();
+        } else if (is_string($object) && $type === 'team') {
+            return $object;
         }
 
         throw new InvalidArgumentException(

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -30,7 +30,7 @@ class Helper
             return call_user_func_array([
                 Config::get("laratrust.models.{$type}"), 'where'
             ], ['name', $object])->firstOrFail()->getKey();
-        } else if (is_string($object) && $type === 'team') {
+        } elseif (is_string($object) && $type === 'team') {
             return $object;
         }
 


### PR DESCRIPTION
With teams enabled and using UUID on your team model

Using `$user->isAbleTo('something', 'team_uuid');` will result in a query being made to fetch the team by name and retrieve it's id, this is invalid behavior as a team doesn't necessarily have a name column and if passing an id, there shouldn't be any need to fetch anyways