### PR TITLE
Bugfix for UrlGenerationException in panel

### DIFF
--- a/resources/views/panel/roles-assignment/index.blade.php
+++ b/resources/views/panel/roles-assignment/index.blade.php
@@ -49,7 +49,7 @@
                 @endif
                 <td class="flex justify-end px-6 py-4 whitespace-no-wrap text-right border-b border-gray-200 text-sm leading-5 font-medium">
                   <a
-                    href="{{route('laratrust.roles-assignment.edit', ['roles_assignment' => $user->id, 'model' => $modelKey])}}"
+                    href="{{route('laratrust.roles-assignment.edit', ['roles_assignment' => $user->getKey(), 'model' => $modelKey])}}"
                     class="text-blue-600 hover:text-blue-900"
                   >Edit</a>
                 </td>


### PR DESCRIPTION
When a model uses a key other then "id", this exception is thrown :

```
Illuminate\Routing\Exceptions\UrlGenerationException
Missing required parameters for [Route: laratrust.roles-assignment.edit] [URI: laratrust/roles-assignment/{roles_assignment}/edit]. (View: /var/www/vendor/santigarcor/laratrust/resources/views/panel/roles-assignment/index.blade.php)
```

This is because `$user->id` may return `NULL`.  
`$user->getKey()` is more appropriate here. Plus, it's already used in the same file on line 37.