### PR TITLE
Turn off cache in non production mode

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -46,7 +46,7 @@ return [
         | NOTE: Currently the database check does not use cache.
         |
         */
-        'enabled' => env('LARATRUST_ENABLE_CACHE', true),
+        'enabled' => env('LARATRUST_ENABLE_CACHE',  config('app.env') === 'production'),
 
         /*
         |--------------------------------------------------------------------------

--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -46,7 +46,7 @@ return [
         | NOTE: Currently the database check does not use cache.
         |
         */
-        'enabled' => env('LARATRUST_ENABLE_CACHE',  config('app.env') === 'production'),
+        'enabled' => env('LARATRUST_ENABLE_CACHE', config('app.env') === 'production'),
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
When in development, seeder changes can change quickly, when the role is cached, this will cause confusion like this #519.