### PR TITLE
Bump kkszymanowski/traitor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "kkszymanowski/traitor": "^0.2.0",
+        "kkszymanowski/traitor": "^1.0",
         "laravel/framework": "~6.0|~7.0|~8.0|^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bump Traitor version to 1.0 to fix issues with adding the trait use statement when the `declare(strict_types=1);` directive is present.

Fixes https://github.com/KKSzymanowski/Traitor/issues/11