### PR TITLE
Fix phpdoc return type of LaratrustUserTrait::getRoles to array.

### DIFF
--- a/src/Traits/LaratrustUserTrait.php
+++ b/src/Traits/LaratrustUserTrait.php
@@ -170,7 +170,7 @@ trait LaratrustUserTrait
      * Get the the names of the user's roles.
      *
      * @param  string|bool   $team      Team name.
-     * @return bool
+     * @return array
      */
     public function getRoles($team = null)
     {


### PR DESCRIPTION
I'm using phpstan.
When I use `LaratrustUserTrait::getRoles` in client code, phpstan tells me that the return value of `getRoles` is `bool`. 
The method defined as

```php
    /**
     * Get the the names of the user's roles.
     *
     * @param  string|bool   $team      Team name.
     * @return bool
     */
    public function getRoles($team = null)
    {
        return $this->laratrustUserChecker()->getCurrentUserRoles($team);
    }
```
 
and `getCurrentUserRoles`'s return value is `array`.

I just changed it to `array`.