### PR TITLE
fix table name in unique rule in role controller

### DIFF
--- a/src/Http/Controllers/RolesController.php
+++ b/src/Http/Controllers/RolesController.php
@@ -49,7 +49,7 @@ class RolesController
     public function store(Request $request)
     {
         $data = $request->validate([
-            'name' => 'required|string|unique:roles,name',
+            'name' => 'required|string|unique:'.\config('laratrust.tables.roles').',name',
             'display_name' => 'nullable|string',
             'description' => 'nullable|string',
         ]);


### PR DESCRIPTION
table names should be used in validation as defined in config files 