### PR TITLE
Prevent string interpolation deprecation notices when using PHP 8.2

### DIFF
--- a/src/Console/MigrationCommand.php
+++ b/src/Console/MigrationCommand.php
@@ -167,6 +167,6 @@ class MigrationCommand extends Command
     {
         $date = $date ?: date('Y_m_d_His');
 
-        return database_path("migrations/${date}_{$this->migrationSuffix}.php");
+        return database_path("migrations/{$date}_{$this->migrationSuffix}.php");
     }
 }

--- a/src/Console/SetupTeamsCommand.php
+++ b/src/Console/SetupTeamsCommand.php
@@ -149,6 +149,6 @@ class SetupTeamsCommand extends Command
     {
         $date = $date ?: date('Y_m_d_His');
 
-        return database_path("migrations/${date}_{$this->migrationSuffix}.php");
+        return database_path("migrations/{$date}_{$this->migrationSuffix}.php");
     }
 }

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -143,6 +143,6 @@ class UpgradeCommand extends Command
     {
         $date = $date ?: date('Y_m_d_His');
 
-        return database_path("migrations/${date}_{$this->migrationSuffix}.php");
+        return database_path("migrations/{$date}_{$this->migrationSuffix}.php");
     }
 }


### PR DESCRIPTION
The following deprecation notices are visible when using this package with PHP 8.2:

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/santigarcor/laratrust/src/Console/MigrationCommand.php on line 170
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/santigarcor/laratrust/src/Console/SetupTeamsCommand.php on line 152
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/santigarcor/laratrust/src/Console/UpgradeCommand.php on line 146
```

This pull request fxies these deprecation notices.