### PR TITLE
fix: correction to index page link for 8.x docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Laratrust is an easy and flexible way to add roles, permissions and teams author
 
 | Laravel       | Laratrust                                                 |
 | :------------ | :-------------------------------------------------------- |
-| 10.x          | [8.x](/docs/8x/)                                          |
+| 10.x          | [8.x](/docs/8.x/)                                          |
 | 9.x-10.x      | [7.x](/docs/7.x/)                                         |
 | 8.x           | [6.x](/docs/6.x/)                                         |
 | 7.x           | [6.x](/docs/6.x/)                                         |


### PR DESCRIPTION
Just the tiniest of typos I noticed when browsing the docs.