### PR TITLE
Add support for UUID on user ID foreign key constraint

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -189,7 +189,7 @@ return [
     | Default value is integer
     |
     */
-    'user_foreign_key_type' => 'integer', //uuid or integer
+    'user_primary_key_type' => 'integer', //uuid or integer
 
     /*
     |--------------------------------------------------------------------------

--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -182,6 +182,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User Foreign Key Type
+    |--------------------------------------------------------------------------
+    |
+    | This configures the data type to be used to set up the user foreign key constraint. example uuid or integer
+    | Default value is integer
+    |
+    */
+    'user_foreign_key_type' => 'integer', //uuid or integer
+
+    /*
+    |--------------------------------------------------------------------------
     | Laratrust Middleware
     |--------------------------------------------------------------------------
     |

--- a/resources/views/migration.blade.php
+++ b/resources/views/migration.blade.php
@@ -46,11 +46,11 @@ class LaratrustSetupTables extends Migration
         // Create table for associating roles to users and teams (Many To Many Polymorphic)
         Schema::create('{{ $laratrust['tables']['role_user'] }}', function (Blueprint $table) {
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['role'] }}');
-@if ($laratrust['user_foreign_key_type'] === 'integer')
+@if ($laratrust['user_primary_key_type'] === 'integer')
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['user'] }}');
 @endif
 
-@if ($laratrust['user_foreign_key_type'] === 'uuid')
+@if ($laratrust['user_primary_key_type'] === 'uuid')
             $table->uuid('{{ $laratrust['foreign_keys']['user'] }}');
 @endif
 
@@ -75,11 +75,11 @@ class LaratrustSetupTables extends Migration
         // Create table for associating permissions to users (Many To Many Polymorphic)
         Schema::create('{{ $laratrust['tables']['permission_user'] }}', function (Blueprint $table) {
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['permission'] }}');
-@if ($laratrust['user_foreign_key_type'] === 'integer')
+@if ($laratrust['user_primary_key_type'] === 'integer')
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['user'] }}');
 @endif
 
-@if ($laratrust['user_foreign_key_type'] === 'uuid')
+@if ($laratrust['user_primary_key_type'] === 'uuid')
             $table->uuid('{{ $laratrust['foreign_keys']['user'] }}');
 @endif
             $table->string('user_type');

--- a/resources/views/migration.blade.php
+++ b/resources/views/migration.blade.php
@@ -46,7 +46,14 @@ class LaratrustSetupTables extends Migration
         // Create table for associating roles to users and teams (Many To Many Polymorphic)
         Schema::create('{{ $laratrust['tables']['role_user'] }}', function (Blueprint $table) {
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['role'] }}');
+@if ($laratrust['user_foreign_key_type'] === 'integer')
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['user'] }}');
+@endif
+
+@if ($laratrust['user_foreign_key_type'] === 'uuid')
+            $table->uuid('{{ $laratrust['foreign_keys']['user'] }}');
+@endif
+
             $table->string('user_type');
 @if ($laratrust['teams']['enabled'])
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();
@@ -68,7 +75,13 @@ class LaratrustSetupTables extends Migration
         // Create table for associating permissions to users (Many To Many Polymorphic)
         Schema::create('{{ $laratrust['tables']['permission_user'] }}', function (Blueprint $table) {
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['permission'] }}');
+@if ($laratrust['user_foreign_key_type'] === 'integer')
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['user'] }}');
+@endif
+
+@if ($laratrust['user_foreign_key_type'] === 'uuid')
+            $table->uuid('{{ $laratrust['foreign_keys']['user'] }}');
+@endif
             $table->string('user_type');
 @if ($laratrust['teams']['enabled'])
             $table->unsignedBigInteger('{{ $laratrust['foreign_keys']['team'] }}')->nullable();


### PR DESCRIPTION
This PR adds support for users table that uses `UUID` as primary keys instead of the default `integer` type