### PR TITLE
add localization support for error messages

### DIFF
--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -46,12 +46,12 @@ class LaratrustMiddleware
         if ($handling == 'abort') {
             $defaultMessage = 'User does not have any of the necessary access rights.';
 
-            return App::abort($handler['code'], $handler['message'] ?? $defaultMessage);
+            return App::abort($handler['code'], __($handler['message']) ?? $defaultMessage);
         }
 
         $redirect = Redirect::to($handler['url']);
         if (! empty($handler['message']['content'])) {
-            $redirect->with($handler['message']['key'], $handler['message']['content']);
+            $redirect->with($handler['message']['key'], __($handler['message']['content']));
         }
 
         return $redirect;


### PR DESCRIPTION
add localization support for error messages.

now one can set abort message in config to 'common.laratrust.abort' and add its translations to locale files.