### PR TITLE
feat: add check_imports workflow & add badge for check_imports

### DIFF
--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -1,0 +1,32 @@
+name: Check Imports
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  check_imports:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress && composer require imanghafoori/laravel-microscope --dev
+
+      - name: Check Imports
+        run: ./vendor/bin/check_imports


### PR DESCRIPTION
Adds import checker to GitHub workflows to reveal "extra" or "wrong" use statements.

This PR also includes a commit to remove an extra import so that the checks pass.

Below is a screenshot of what happens if we do not include the latest commit in this PR:
![Screenshot from 2024-01-06 22-19-52](https://github.com/santigarcor/laratrust/assets/70389233/0af8d787-0b31-44be-ac2a-39bad5b033ab)
