### PR TITLE
Add once() Helper Function To Role and Permission Checking.

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -83,6 +83,19 @@ return [
         |
         */
         'expiration_time' => 3600,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Use the once() memoization function
+        |--------------------------------------------------------------------------
+        |
+        | Determines if the once() function should be used to cache the roles and permissions
+        | during the request. Only enable this if you are running Laravel 11 or above.
+        | If you are running Laravel 10 or below, you will need to require the
+        | spatie/once package via composer.
+        |
+        */
+        'once' => false,
     ],
 
     /*

--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -173,6 +173,16 @@ trait HasRolesAndPermissions
         mixed $team = null,
         bool $requireAll = false
     ): bool {
+        if(Config::get('laratrust.cache.once')){
+            return once(function () use ($name, $team, $requireAll) {
+                return $this->laratrustUserChecker()->currentUserHasRole(
+                    $name,
+                    $team,
+                    $requireAll
+                );
+            });
+        }
+
         return $this->laratrustUserChecker()->currentUserHasRole(
             $name,
             $team,
@@ -188,6 +198,16 @@ trait HasRolesAndPermissions
         mixed $team = null,
         bool $requireAll = false
     ): bool {
+        if(Config::get('laratrust.cache.once')) {
+            return once(function () use ($permission, $team, $requireAll) {
+                return $this->laratrustUserChecker()->currentUserHasPermission(
+                    $permission,
+                    $team,
+                    $requireAll
+                );
+            });
+        }
+        
         return $this->laratrustUserChecker()->currentUserHasPermission(
             $permission,
             $team,

--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -173,7 +173,7 @@ trait HasRolesAndPermissions
         mixed $team = null,
         bool $requireAll = false
     ): bool {
-        if(Config::get('laratrust.cache.once')){
+        if (Config::get('laratrust.cache.once')) {
             return once(function () use ($name, $team, $requireAll) {
                 return $this->laratrustUserChecker()->currentUserHasRole(
                     $name,
@@ -198,7 +198,7 @@ trait HasRolesAndPermissions
         mixed $team = null,
         bool $requireAll = false
     ): bool {
-        if(Config::get('laratrust.cache.once')) {
+        if (Config::get('laratrust.cache.once')) {
             return once(function () use ($permission, $team, $requireAll) {
                 return $this->laratrustUserChecker()->currentUserHasPermission(
                     $permission,
@@ -207,7 +207,7 @@ trait HasRolesAndPermissions
                 );
             });
         }
-        
+
         return $this->laratrustUserChecker()->currentUserHasPermission(
             $permission,
             $team,

--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -173,7 +173,7 @@ trait HasRolesAndPermissions
         mixed $team = null,
         bool $requireAll = false
     ): bool {
-        if (Config::get('laratrust.cache.once')) {
+        if (Config::get('laratrust.cache.once') && function_exists('once')) {
             return once(function () use ($name, $team, $requireAll) {
                 return $this->laratrustUserChecker()->currentUserHasRole(
                     $name,
@@ -198,7 +198,7 @@ trait HasRolesAndPermissions
         mixed $team = null,
         bool $requireAll = false
     ): bool {
-        if (Config::get('laratrust.cache.once')) {
+        if (Config::get('laratrust.cache.once') && function_exists('once')) {
             return once(function () use ($permission, $team, $requireAll) {
                 return $this->laratrustUserChecker()->currentUserHasPermission(
                     $permission,

--- a/tests/Checkers/User/CheckerTestCase.php
+++ b/tests/Checkers/User/CheckerTestCase.php
@@ -92,10 +92,6 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->assertFalse($this->user->hasRole('role_c'));
         $this->app['config']->set('laratrust.teams.strict_check', false);
         $this->assertTrue($this->user->hasRole('role_c', 'team_a'));
-        $this->app['config']->set('laratrust.cache.once', true);
-        $this->assertTrue($this->user->hasRole('role_c'));
-        $this->app['config']->set('laratrust.cache.once', false);
-        $this->assertTrue($this->user->hasRole('role_c', 'team_a'));
         $this->assertFalse($this->user->hasRole(EnumsRole::ROLE_A, 'team_a'));
 
         $this->assertTrue($this->user->hasRole('role_a|role_b'));
@@ -152,10 +148,6 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->app['config']->set('laratrust.teams.strict_check', true);
         $this->assertFalse($this->user->hasPermission('permission_c'));
         $this->app['config']->set('laratrust.teams.strict_check', false);
-        $this->assertTrue($this->user->hasPermission('permission_c'));
-        $this->app['config']->set('laratrust.cache.once', true);
-        $this->assertTrue($this->user->hasPermission('permission_c'));
-        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertTrue($this->user->hasPermission('permission_c'));
         $this->assertTrue($this->user->hasPermission('permission_c', 'team_a'));
         $this->assertTrue($this->user->hasPermission('permission_c', $team));

--- a/tests/Checkers/User/CheckerTestCase.php
+++ b/tests/Checkers/User/CheckerTestCase.php
@@ -244,6 +244,7 @@ abstract class CheckerTestCase extends LaratrustTestCase
 
         // With cache
         $this->app['config']->set('laratrust.cache.enabled', true);
+        $this->app['config']->set('laratrust.cache.once', true);
         $this->user->hasRole('some_role');
         $this->user->hasPermission('some_permission');
         $this->assertTrue(Cache::has("laratrust_roles_for_users_{$this->user->id}"));
@@ -252,6 +253,7 @@ abstract class CheckerTestCase extends LaratrustTestCase
 
         // Without cache
         $this->app['config']->set('laratrust.cache.enabled', false);
+        $this->app['config']->set('laratrust.cache.once', false);
         $this->user->hasRole('some_role');
         $this->user->hasPermission('some_permission');
         $this->assertFalse(Cache::has("laratrust_roles_for_users_{$this->user->id}"));

--- a/tests/Checkers/User/CheckerTestCase.php
+++ b/tests/Checkers/User/CheckerTestCase.php
@@ -92,6 +92,10 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->assertFalse($this->user->hasRole('role_c'));
         $this->app['config']->set('laratrust.teams.strict_check', false);
         $this->assertTrue($this->user->hasRole('role_c', 'team_a'));
+        $this->app['config']->set('laratrust.cache.once', true);
+        $this->assertTrue($this->user->hasRole('role_c'));
+        $this->app['config']->set('laratrust.cache.once', false);
+        $this->assertTrue($this->user->hasRole('role_c', 'team_a'));
         $this->assertFalse($this->user->hasRole(EnumsRole::ROLE_A, 'team_a'));
 
         $this->assertTrue($this->user->hasRole('role_a|role_b'));
@@ -148,6 +152,10 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->app['config']->set('laratrust.teams.strict_check', true);
         $this->assertFalse($this->user->hasPermission('permission_c'));
         $this->app['config']->set('laratrust.teams.strict_check', false);
+        $this->assertTrue($this->user->hasPermission('permission_c'));
+        $this->app['config']->set('laratrust.cache.once', true);
+        $this->assertTrue($this->user->hasPermission('permission_c'));
+        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertTrue($this->user->hasPermission('permission_c'));
         $this->assertTrue($this->user->hasPermission('permission_c', 'team_a'));
         $this->assertTrue($this->user->hasPermission('permission_c', $team));

--- a/tests/Checkers/User/CheckerTestCase.php
+++ b/tests/Checkers/User/CheckerTestCase.php
@@ -234,7 +234,16 @@ abstract class CheckerTestCase extends LaratrustTestCase
             Permission::create(['name' => 'permission_e'])->id => ['team_id' => $team->id],
         ]);
 
-        // With cache
+        // With cache and without once
+        $this->app['config']->set('laratrust.cache.enabled', true);
+        $this->app['config']->set('laratrust.cache.once', false);
+        $this->user->hasRole('some_role');
+        $this->user->hasPermission('some_permission');
+        $this->assertTrue(Cache::has("laratrust_roles_for_users_{$this->user->id}"));
+        $this->assertTrue(Cache::has("laratrust_permissions_for_users_{$this->user->id}"));
+        $this->user->flushCache();
+        
+        //With cache and once
         $this->app['config']->set('laratrust.cache.enabled', true);
         $this->app['config']->set('laratrust.cache.once', true);
         $this->user->hasRole('some_role');
@@ -243,7 +252,15 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->assertTrue(Cache::has("laratrust_permissions_for_users_{$this->user->id}"));
         $this->user->flushCache();
 
-        // Without cache
+        // Without cache and with once
+        $this->app['config']->set('laratrust.cache.enabled', false);
+        $this->app['config']->set('laratrust.cache.once', true);
+        $this->user->hasRole('some_role');
+        $this->user->hasPermission('some_permission');
+        $this->assertFalse(Cache::has("laratrust_roles_for_users_{$this->user->id}"));
+        $this->assertFalse(Cache::has("laratrust_permissions_for_users_{$this->user->id}"));
+        
+        //Without cache and without once
         $this->app['config']->set('laratrust.cache.enabled', false);
         $this->app['config']->set('laratrust.cache.once', false);
         $this->user->hasRole('some_role');

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -38,22 +38,18 @@ class UserTest extends LaratrustTestCase
     public function testPermissionsRelationship()
     {
         $this->app['config']->set('laratrust.teams.enabled', false);
-        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertInstanceOf(MorphToMany::class, $this->user->permissions());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
-        $this->app['config']->set('laratrust.cache.once', true);
         $this->assertInstanceOf(MorphToMany::class, $this->user->permissions());
     }
 
     public function testRolesTeams()
     {
         $this->app['config']->set('laratrust.teams.enabled', false);
-        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertNull($this->user->rolesTeams());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
-        $this->app['config']->set('laratrust.cache.once', true);
         $this->assertInstanceOf(MorphToMany::class, $this->user->rolesTeams());
     }
 
@@ -74,11 +70,9 @@ class UserTest extends LaratrustTestCase
         |------------------------------------------------------------
         */
         $this->app['config']->set('laratrust.teams.enabled', false);
-        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertNull($this->user->permissionsTeams());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
-        $this->app['config']->set('laratrust.cache.once', true);
         $this->assertInstanceOf(
             '\Illuminate\Database\Eloquent\Relations\MorphToMany',
             $this->user->permissionsTeams()
@@ -126,11 +120,9 @@ class UserTest extends LaratrustTestCase
 
 
         $this->app['config']->set('laratrust.teams.enabled', false);
-        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertEmpty($this->user->allTeams());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
-        $this->app['config']->set('laratrust.cache.once', true);
 
         $this->assertSame(
             ['team_a', 'team_b',],

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -38,18 +38,22 @@ class UserTest extends LaratrustTestCase
     public function testPermissionsRelationship()
     {
         $this->app['config']->set('laratrust.teams.enabled', false);
+        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertInstanceOf(MorphToMany::class, $this->user->permissions());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
+        $this->app['config']->set('laratrust.cache.once', true);
         $this->assertInstanceOf(MorphToMany::class, $this->user->permissions());
     }
 
     public function testRolesTeams()
     {
         $this->app['config']->set('laratrust.teams.enabled', false);
+        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertNull($this->user->rolesTeams());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
+        $this->app['config']->set('laratrust.cache.once', true);
         $this->assertInstanceOf(MorphToMany::class, $this->user->rolesTeams());
     }
 
@@ -70,9 +74,11 @@ class UserTest extends LaratrustTestCase
         |------------------------------------------------------------
         */
         $this->app['config']->set('laratrust.teams.enabled', false);
+        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertNull($this->user->permissionsTeams());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
+        $this->app['config']->set('laratrust.cache.once', true);
         $this->assertInstanceOf(
             '\Illuminate\Database\Eloquent\Relations\MorphToMany',
             $this->user->permissionsTeams()
@@ -120,9 +126,11 @@ class UserTest extends LaratrustTestCase
 
 
         $this->app['config']->set('laratrust.teams.enabled', false);
+        $this->app['config']->set('laratrust.cache.once', false);
         $this->assertEmpty($this->user->allTeams());
 
         $this->app['config']->set('laratrust.teams.enabled', true);
+        $this->app['config']->set('laratrust.cache.once', true);
 
         $this->assertSame(
             ['team_a', 'team_b',],


### PR DESCRIPTION
This PR adds the new `once()` helper function to Laratrust along with the option to enable/disable it via the configuration file.

This is useful as it removes the need to override the `hasRole()` and `hasPermission()` methods on the user model and instead moves this logic into Laratrust itself.

The default is that the use of this function is disabled due to the `once()` function not being added into Laravel Core until Laravel 11. The inline documentation comment with this configuration states that the application must be running Laravel 11 in order to use this function. The comment also states that if the application is running Laravel 10 or below, they need to run `composer require spatie/once`