### PR TITLE
Per Request Cache

### DIFF
--- a/src/Checkers/Role/RoleDefaultChecker.php
+++ b/src/Checkers/Role/RoleDefaultChecker.php
@@ -64,10 +64,9 @@ class RoleDefaultChecker extends RoleChecker
     {
         $cacheKey = 'laratrust_permissions_for_role_'.$this->role->getKey();
 
-        return Cache::store('array')
-            ->rememberForever(
+        return Cache::store('array')->rememberForever(
                 $cacheKey,
-                function() {
+                function() use ($cacheKey) {
                     if (! Config::get('laratrust.cache.enabled')) {
                         return $this->role->permissions()->get()->toArray();
                     }

--- a/src/Checkers/User/UserDefaultChecker.php
+++ b/src/Checkers/User/UserDefaultChecker.php
@@ -152,13 +152,17 @@ class UserDefaultChecker extends UserChecker
     {
         $cacheKey = 'laratrust_roles_for_'.$this->userModelCacheKey().'_'.$this->user->getKey();
 
-        if (! Config::get('laratrust.cache.enabled')) {
-            return $this->user->roles()->get()->toArray();
-        }
-
-        return Cache::remember($cacheKey, Config::get('laratrust.cache.expiration_time', 60), function () {
-            return $this->user->roles()->get()->toArray();
-        });
+        return Cache::store('array')->rememberForever(
+            $cacheKey,
+            function() {
+                if (! Config::get('laratrust.cache.enabled')) {
+                    return $this->user->roles()->get()->toArray();
+                }
+        
+                return Cache::remember($cacheKey, Config::get('laratrust.cache.expiration_time', 60), function () {
+                    return $this->user->roles()->get()->toArray();
+                });
+            });
     }
 
     /**
@@ -170,13 +174,17 @@ class UserDefaultChecker extends UserChecker
     {
         $cacheKey = 'laratrust_permissions_for_'.$this->userModelCacheKey().'_'.$this->user->getKey();
 
-        if (! Config::get('laratrust.cache.enabled')) {
-            return $this->user->permissions()->get()->toArray();
-        }
-
-        return Cache::remember($cacheKey, Config::get('laratrust.cache.expiration_time', 60), function () {
-            return $this->user->permissions()->get()->toArray();
-        });
+        return Cache::store('array')->rememberForever(
+            $cacheKey,
+            function() {
+                if (! Config::get('laratrust.cache.enabled')) {
+                    return $this->user->permissions()->get()->toArray();
+                }
+        
+                return Cache::remember($cacheKey, Config::get('laratrust.cache.expiration_time', 60), function () {
+                    return $this->user->permissions()->get()->toArray();
+                });
+            });
     }
 
     /**

--- a/src/Checkers/User/UserDefaultChecker.php
+++ b/src/Checkers/User/UserDefaultChecker.php
@@ -154,7 +154,7 @@ class UserDefaultChecker extends UserChecker
 
         return Cache::store('array')->rememberForever(
             $cacheKey,
-            function() {
+            function() use ($cacheKey) {
                 if (! Config::get('laratrust.cache.enabled')) {
                     return $this->user->roles()->get()->toArray();
                 }
@@ -176,7 +176,7 @@ class UserDefaultChecker extends UserChecker
 
         return Cache::store('array')->rememberForever(
             $cacheKey,
-            function() {
+            function() use ($cacheKey)  {
                 if (! Config::get('laratrust.cache.enabled')) {
                     return $this->user->permissions()->get()->toArray();
                 }


### PR DESCRIPTION
This would allow for in memory caching instead of pinging the "real" cache store each time. Noticed large number of requests  when using Laravel Nova with Laratrust. When Nova is checking the policies (which check user permissions and roles) it makes 100+ requests which is unnecessary for single request.

**Before**

![image](https://github.com/user-attachments/assets/97fdb8e1-3a01-4c66-ad61-25efbd7c81ff)
![image](https://github.com/user-attachments/assets/3aa6f62c-8981-4ace-bdce-4e5eb3c1ccc2)

**After**

![image](https://github.com/user-attachments/assets/af089674-91f8-4c37-a6e0-58d78078a03f)
![image](https://github.com/user-attachments/assets/19367668-419e-461f-a79f-39c6fdbc8f28)

_Captures from Laravel Telescope_