### PR TITLE
Fix php 8.4 deprecated types

### DIFF
--- a/src/Contracts/LaratrustUser.php
+++ b/src/Contracts/LaratrustUser.php
@@ -150,5 +150,5 @@ interface LaratrustUser
      *
      * @return Collection<\Laratrust\Contracts\Permission>
      */
-    public function allPermissions(array $columns = null, $team = false): Collection;
+    public function allPermissions(?array $columns = null, bool $team = false): Collection;
 }

--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -498,7 +498,7 @@ trait HasRolesAndPermissions
      *
      * @return Collection<\Laratrust\Contracts\Permission>
      */
-    public function allPermissions(array $columns = null, $team = false): Collection
+    public function allPermissions(?array $columns = null, bool $team = false): Collection
     {
         $columns = is_array($columns) ? $columns : null;
         if ($columns) {


### PR DESCRIPTION
Fix the PHP 8.4 warning messages:

PHP Deprecated:  Laratrust\Traits\HasRolesAndPermissions::allPermissions(): Implicitly marking parameter $columns as nullable is deprecated, the explicit nullable type must be used instead in /vendor/santigarcor/laratrust/src/Traits/HasRolesAndPermissions.php on line 501

PHP Deprecated:  Laratrust\Contracts\LaratrustUser::allPermissions(): Implicitly marking parameter $columns as nullable is deprecated, the explicit nullable type must be used instead in /vendor/santigarcor/laratrust/src/Contracts/LaratrustUser.php on line 153