### PR TITLE
Fix implicitly nullable parameter

### DIFF
--- a/src/Checkers/User/UserDefaultChecker.php
+++ b/src/Checkers/User/UserDefaultChecker.php
@@ -227,7 +227,7 @@ class UserDefaultChecker extends UserChecker
     /**
      * Check if a role or permission is added to the user in a same team.
      */
-    private function isInSameTeam($rolePermission, int|string $teamId = null): bool
+    private function isInSameTeam($rolePermission, int|string|null $teamId = null): bool
     {
         if (
             ! Config::get('laratrust.teams.enabled')

--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -53,5 +53,5 @@ interface Role
     /**
      * Detach multiple permissions from current role.
      */
-    public function removePermissions(iterable $permissions = null): static;
+    public function removePermissions(?iterable $permissions = null): static;
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -152,7 +152,7 @@ class Role extends Model implements RoleContract
         return $this;
     }
 
-    public function removePermissions(iterable $permissions = null): static
+    public function removePermissions(?iterable $permissions = null): static
     {
         if (! $permissions) {
             $this->syncPermissions([]);


### PR DESCRIPTION
Starting PHP 8.4, implicitly nullable parameter will trigger a deprecated message. And will remove the support in PHP 9 per RFC https://wiki.php.net/rfc/deprecate-implicitly-nullable-types