### PR TITLE
feat(LaratrustMiddleware@unauthorized): Add JSON response handling for unauthorized access

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -226,6 +226,24 @@ return [
                     'content' => '',
                 ],
             ],
+
+            
+            /**
+             * Defines a custom JSON response format for unauthorized access.
+             * This can be used when a JSON response is preferred over a redirect or abort.
+             *
+             * - 'code': The HTTP status code to return (default: 403).
+             * - 'include_timestamp': Whether to include a timestamp in the response (true/false).
+             * - 'structure': Defines the JSON response format.
+             */
+            'json'     => [
+                'code'              => 403,
+                'include_timestamp' => true,
+                'structure'         => [
+                    'status'  => 'error',
+                    'message' => 'User does not have the necessary access rights to perform this action.',
+                ],
+            ],
         ],
     ],
 

--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -236,11 +236,11 @@ return [
              * - 'include_timestamp': Whether to include a timestamp in the response (true/false).
              * - 'structure': Defines the JSON response format.
              */
-            'json'     => [
-                'code'              => 403,
+            'json' => [
+                'code' => 403,
                 'include_timestamp' => true,
-                'structure'         => [
-                    'status'  => 'error',
+                'structure' => [
+                    'status' => 'error',
                     'message' => 'User does not have the necessary access rights to perform this action.',
                 ],
             ],

--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -226,7 +226,7 @@ return [
                     'content' => '',
                 ],
             ],
-            
+
             /**
              * Defines a custom JSON response format for unauthorized access.
              * This can be used when a JSON response is preferred over a redirect or abort.

--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -226,7 +226,6 @@ return [
                     'content' => '',
                 ],
             ],
-
             
             /**
              * Defines a custom JSON response format for unauthorized access.

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -49,6 +49,16 @@ class LaratrustMiddleware
             return App::abort($handler['code'], $handler['message'] ?? $defaultMessage);
         }
 
+        if ($handling === "json") {
+            $responseData = $handler['structure'] ?? [];
+
+            if (!empty($handler['include_timestamp']) && boolval($handler['include_timestamp'])) {
+                $responseData['timestamp'] = now()->toISOString();
+            }
+        
+            return response()->json($responseData, $handler['code'] ?? 403);
+        }
+
         $redirect = Redirect::to($handler['url']);
         if (! empty($handler['message']['content'])) {
             $redirect->with($handler['message']['key'], $handler['message']['content']);

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -52,10 +52,10 @@ class LaratrustMiddleware
         if ($handling == 'json') {
             $responseData = $handler['structure'] ?? [];
 
-            if (!empty($handler['include_timestamp']) && boolval($handler['include_timestamp'])) {
+            if (! empty($handler['include_timestamp']) && boolval($handler['include_timestamp'])) {
                 $responseData['timestamp'] = now()->toISOString();
             }
-        
+
             return response()->json($responseData, $handler['code'] ?? 403);
         }
 

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -49,7 +49,7 @@ class LaratrustMiddleware
             return App::abort($handler['code'], $handler['message'] ?? $defaultMessage);
         }
 
-        if ($handling == "json") {
+        if ($handling == 'json') {
             $responseData = $handler['structure'] ?? [];
 
             if (!empty($handler['include_timestamp']) && boolval($handler['include_timestamp'])) {

--- a/src/Middleware/LaratrustMiddleware.php
+++ b/src/Middleware/LaratrustMiddleware.php
@@ -49,7 +49,7 @@ class LaratrustMiddleware
             return App::abort($handler['code'], $handler['message'] ?? $defaultMessage);
         }
 
-        if ($handling === "json") {
+        if ($handling == "json") {
             $responseData = $handler['structure'] ?? [];
 
             if (!empty($handler['include_timestamp']) && boolval($handler['include_timestamp'])) {


### PR DESCRIPTION
##  **What’s New?**  
- **Added JSON response handling** to `unauthorized()` method in `LaratrustMiddleware`.  
- If `laratrust.middleware.handling` is set to `json`, the middleware will return a **structured JSON response** instead of redirecting or aborting.  

---

##  **Why This Change?**  
- Improves **API support** by providing standardized **JSON responses**.  
- Enhances **maintainability** and **scalability** by allowing response customization via `config/laratrust.php`.  

---

##  **Changes Made**  
- Updated `unauthorized()` to support JSON response.  
- Introduced a new `json` handling option in `config/laratrust.php`, with:  
  - Customizable **HTTP status code** (`code`).  
  - Optional **timestamp inclusion** (`include_timestamp`).  
  - Flexible **response structure** (`structure`).  
- Maintained **full compatibility** with existing `abort` and `redirect` handlers.  

---

##  **How to Test?**  
1. Update `config/laratrust.php`:  
   ```php
    'middleware' => [
        /**
         * Define if the laratrust middleware are registered automatically in the service provider.
         */
        'register' => true,

        /**
         * Method to be called in the middleware return case.
         * Available: abort|redirect.
         */
        'handling' => 'json',

        /**
         * Handlers for the unauthorized method in the middlewares.
         * The name of the handler must be the same as the handling.
         */
        'handlers' => [
            /**
             * Aborts the execution with a 403 code and allows you to provide the response text.
             */
            'abort' => [
                'code' => 403,
                'message' => 'User does not have any of the necessary access rights.',
            ],

            /**
             * Redirects the user to the given url.
             * If you want to flash a key to the session,
             * you can do it by setting the key and the content of the message
             * If the message content is empty it won't be added to the redirection.
             */
            'redirect' => [
                'url' => '/home',
                'message' => [
                    'key' => 'error',
                    'content' => '',
                ],
            ],


            /**
             * Defines a custom JSON response format for unauthorized access.
             * This can be used when a JSON response is preferred over a redirect or abort.
             *
             * - 'code': The HTTP status code to return (default: 403).
             * - 'include_timestamp': Whether to include a timestamp in the response (true/false).
             * - 'structure': Defines the JSON response format.
             */
            'json'     => [
                'code'              => 403,
                'include_timestamp' => false,
                'structure'         => [
                    'status'  => 'error',
                    'message' => 'User does not have the necessary access rights to perform this action.',
                ],
            ],
        ],
    ],
   ```  
2. Run `php artisan config:clear` to apply the changes.  
3. Trigger an unauthorized request (e.g., accessing a protected route without permissions).  
4. You should receive a JSON response like:  
   ```json
   {
       "status": "error",
       "message": "User does not have the necessary access rights to perform this action.",
       "timestamp": "2024-07-01T12:34:56.789Z"
   }
   ```

---

**Let me know if you need any adjustments**