### PR TITLE
Add `doesntHavePermission` and `isNotAbleTo` methods

### DIFF
--- a/src/Laratrust.php
+++ b/src/Laratrust.php
@@ -52,6 +52,17 @@ class Laratrust
     }
 
     /**
+     * Check if the current user does not have a permission by its name.
+     */
+    public function doesntHavePermission(
+        string|array|BackedEnum $permission,
+        mixed $team = null,
+        bool $requireAll = false
+    ): bool {
+        return ! $this->hasPermission($permission, $team, $requireAll);
+    }
+
+    /**
      * Check if the current user has a permission by its name.
      * Alias to hasPermission.
      */
@@ -61,6 +72,18 @@ class Laratrust
         bool $requireAll = false
     ): bool {
         return $this->hasPermission($permission, $team, $requireAll);
+    }
+
+    /**
+     * Check if the current user does not have a permission by its name.
+     * Alias to doesntHavePermission.
+     */
+    public function isNotAbleTo(
+        string|array|BackedEnum $permission,
+        mixed $team = null,
+        bool $requireAll = false
+    ): bool {
+        return $this->doesntHavePermission($permission, $team, $requireAll);
     }
 
     /**

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -106,6 +106,11 @@ class Role extends Model implements RoleContract
             ->currentRoleHasPermission($permission, $requireAll);
     }
 
+    public function doesntHavePermission(string|array|BackedEnum $permission, bool $requireAll = false): bool
+    {
+        return !$this->hasPermission($permission, $requireAll);
+    }
+
     public function syncPermissions(iterable $permissions): static
     {
         $mappedPermissions = [];

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -108,7 +108,7 @@ class Role extends Model implements RoleContract
 
     public function doesntHavePermission(string|array|BackedEnum $permission, bool $requireAll = false): bool
     {
-        return !$this->hasPermission($permission, $requireAll);
+        return ! $this->hasPermission($permission, $requireAll);
     }
 
     public function syncPermissions(iterable $permissions): static

--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -196,6 +196,17 @@ trait HasRolesAndPermissions
     }
 
     /**
+     * Check if user does not have a permission by its name.
+     */
+    public function doesntHavePermission(
+        string|array|BackedEnum $permission,
+        mixed $team = null,
+        bool $requireAll = false
+    ): bool {
+        return ! $this->hasPermission($permission, $team, $requireAll);
+    }
+
+    /**
      * Check if user has a permission by its name.
      */
     public function isAbleTo(
@@ -204,6 +215,17 @@ trait HasRolesAndPermissions
         bool $requireAll = false
     ): bool {
         return $this->hasPermission($permission, $team, $requireAll);
+    }
+
+    /**
+     * Check if user does not have a permission by its name.
+     */
+    public function isNotAbleTo(
+        string|array|BackedEnum $permission,
+        mixed $team = null,
+        bool $requireAll = false
+    ): bool {
+        return ! $this->isAbleTo($permission, $team, $requireAll);
     }
 
     /**

--- a/tests/Checkers/Role/DefaultCheckerTest.php
+++ b/tests/Checkers/Role/DefaultCheckerTest.php
@@ -34,9 +34,18 @@ class DefaultCheckerTest extends LaratrustTestCase
         $this->assertTrue($this->role->hasPermission('permission_b'));
         $this->assertFalse($this->role->hasPermission('permission_c'));
 
+        $this->assertFalse($this->role->doesntHavePermission(EnumsPermission::PERM_A));
+        $this->assertFalse($this->role->doesntHavePermission('permission_b'));
+        $this->assertTrue($this->role->doesntHavePermission('permission_c'));
+
         $this->assertTrue($this->role->hasPermission([EnumsPermission::PERM_A, 'permission_b']));
         $this->assertTrue($this->role->hasPermission(['permission_a', 'permission_c']));
         $this->assertFalse($this->role->hasPermission([EnumsPermission::PERM_A, 'permission_c'], true));
         $this->assertFalse($this->role->hasPermission(['permission_c', 'permission_d']));
+
+        $this->assertFalse($this->role->doesntHavePermission([EnumsPermission::PERM_A, 'permission_b']));
+        $this->assertFalse($this->role->doesntHavePermission(['permission_a', 'permission_c']));
+        $this->assertTrue($this->role->doesntHavePermission([EnumsPermission::PERM_A, 'permission_c'], true));
+        $this->assertTrue($this->role->doesntHavePermission(['permission_c', 'permission_d']));
     }
 }

--- a/tests/Checkers/Role/LaratrustRoleCustomCheckerTest.php
+++ b/tests/Checkers/Role/LaratrustRoleCustomCheckerTest.php
@@ -44,9 +44,18 @@ class LaratrustRoleCustomCheckerTest extends LaratrustTestCase
         $this->assertTrue($this->role->hasPermission('permission_b'));
         $this->assertFalse($this->role->hasPermission('permission_c'));
 
+        $this->assertFalse($this->role->doesntHavePermission(EnumsPermission::PERM_A));
+        $this->assertFalse($this->role->doesntHavePermission('permission_b'));
+        $this->assertTrue($this->role->doesntHavePermission('permission_c'));
+
         $this->assertTrue($this->role->hasPermission(['permission_a', 'permission_b']));
         $this->assertTrue($this->role->hasPermission(['permission_a', 'permission_c']));
         $this->assertFalse($this->role->hasPermission([EnumsPermission::PERM_A, 'permission_c'], true));
         $this->assertFalse($this->role->hasPermission(['permission_c', 'permission_d']));
+
+        $this->assertFalse($this->role->doesntHavePermission(['permission_a', 'permission_b']));
+        $this->assertFalse($this->role->doesntHavePermission(['permission_a', 'permission_c']));
+        $this->assertTrue($this->role->doesntHavePermission([EnumsPermission::PERM_A, 'permission_c'], true));
+        $this->assertTrue($this->role->doesntHavePermission(['permission_c', 'permission_d']));
     }
 }

--- a/tests/Checkers/Role/QueryCheckerTest.php
+++ b/tests/Checkers/Role/QueryCheckerTest.php
@@ -34,9 +34,18 @@ class QueryCheckerTest extends LaratrustTestCase
         $this->assertTrue($this->role->hasPermission('permission_b'));
         $this->assertFalse($this->role->hasPermission('permission_c'));
 
+        $this->assertFalse($this->role->doesntHavePermission(EnumsPermission::PERM_A));
+        $this->assertFalse($this->role->doesntHavePermission('permission_b'));
+        $this->assertTrue($this->role->doesntHavePermission('permission_c'));
+
         $this->assertTrue($this->role->hasPermission(['permission_a', 'permission_b']));
         $this->assertTrue($this->role->hasPermission(['permission_a', 'permission_c']));
         $this->assertFalse($this->role->hasPermission([EnumsPermission::PERM_A, 'permission_c'], true));
         $this->assertFalse($this->role->hasPermission(['permission_c', 'permission_d']));
+
+        $this->assertFalse($this->role->doesntHavePermission(['permission_a', 'permission_b']));
+        $this->assertFalse($this->role->doesntHavePermission(['permission_a', 'permission_c']));
+        $this->assertTrue($this->role->doesntHavePermission([EnumsPermission::PERM_A, 'permission_c'], true));
+        $this->assertTrue($this->role->doesntHavePermission(['permission_c', 'permission_d']));
     }
 }

--- a/tests/Checkers/User/CheckerTestCase.php
+++ b/tests/Checkers/User/CheckerTestCase.php
@@ -145,14 +145,23 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->assertTrue($this->user->hasPermission(EnumsPermission::PERM_A));
         $this->assertTrue($this->user->hasPermission('permission_b', 'team_a'));
         $this->assertTrue($this->user->hasPermission('permission_b', $team));
+        $this->assertFalse($this->user->doesntHavePermission(EnumsPermission::PERM_A));
+        $this->assertFalse($this->user->doesntHavePermission('permission_b', 'team_a'));
+        $this->assertFalse($this->user->doesntHavePermission('permission_b', $team));
         $this->app['config']->set('laratrust.teams.strict_check', true);
         $this->assertFalse($this->user->hasPermission('permission_c'));
+        $this->assertTrue($this->user->doesntHavePermission('permission_c'));
         $this->app['config']->set('laratrust.teams.strict_check', false);
         $this->assertTrue($this->user->hasPermission('permission_c'));
         $this->assertTrue($this->user->hasPermission('permission_c', 'team_a'));
         $this->assertTrue($this->user->hasPermission('permission_c', $team));
         $this->assertTrue($this->user->hasPermission('permission_d'));
         $this->assertFalse($this->user->hasPermission('permission_e'));
+        $this->assertFalse($this->user->doesntHavePermission('permission_c'));
+        $this->assertFalse($this->user->doesntHavePermission('permission_c', 'team_a'));
+        $this->assertFalse($this->user->doesntHavePermission('permission_c', $team));
+        $this->assertFalse($this->user->doesntHavePermission('permission_d'));
+        $this->assertTrue($this->user->doesntHavePermission('permission_e'));
 
         $this->assertTrue($this->user->hasPermission([EnumsPermission::PERM_A, 'permission_b', 'permission_c', 'permission_d', 'permission_e']));
         $this->assertTrue($this->user->hasPermission('permission_a|permission_b|permission_c|permission_d|permission_e'));
@@ -163,13 +172,26 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->assertFalse($this->user->hasPermission(['permission_a', 'permission_b', 'permission_e'], requireAll: true));
         $this->assertFalse($this->user->hasPermission(['permission_e', 'permission_f']));
 
+        $this->assertFalse($this->user->doesntHavePermission([EnumsPermission::PERM_A, 'permission_b', 'permission_c', 'permission_d', 'permission_e']));
+        $this->assertFalse($this->user->doesntHavePermission('permission_a|permission_b|permission_c|permission_d|permission_e'));
+        $this->assertFalse($this->user->doesntHavePermission(['permission_a', 'permission_d'], requireAll: true));
+        $this->assertFalse($this->user->doesntHavePermission(['permission_a', 'permission_b', 'permission_d'], requireAll: true));
+        $this->assertTrue($this->user->doesntHavePermission([EnumsPermission::PERM_A, 'permission_b', 'permission_d'], 'team_a', true));
+        $this->assertTrue($this->user->doesntHavePermission(['permission_a', 'permission_b', 'permission_d'], $team, true));
+        $this->assertTrue($this->user->doesntHavePermission(['permission_a', 'permission_b', 'permission_e'], requireAll: true));
+        $this->assertTrue($this->user->doesntHavePermission(['permission_e', 'permission_f']));
+
         $this->app['config']->set('laratrust.teams.enabled', false);
         $this->assertTrue($this->user->hasPermission(['permission_a', 'permission_b', 'permission_d'], 'team_a', true));
         $this->assertTrue($this->user->hasPermission(['permission_a', 'permission_b', 'permission_d'], $team, true));
+        $this->assertFalse($this->user->doesntHavePermission(['permission_a', 'permission_b', 'permission_d'], 'team_a', true));
+        $this->assertFalse($this->user->doesntHavePermission(['permission_a', 'permission_b', 'permission_d'], $team, true));
 
         $this->app['config']->set('laratrust.cache.enabled', false);
         $this->assertTrue($this->user->hasPermission('permission_b', 'team_a'));
         $this->assertTrue($this->user->hasPermission('permission_c', 'team_a'));
+        $this->assertFalse($this->user->doesntHavePermission('permission_b', 'team_a'));
+        $this->assertFalse($this->user->doesntHavePermission('permission_c', 'team_a'));
     }
 
     protected function hasPermissionWithPlaceholderSupportAssertions()
@@ -205,11 +227,22 @@ abstract class CheckerTestCase extends LaratrustTestCase
         $this->assertTrue($this->user->hasPermission('admin.users'));
         $this->assertFalse($this->user->hasPermission('admin.config', 'team_a'));
 
+        $this->assertFalse($this->user->doesntHavePermission('admin.posts'));
+        $this->assertFalse($this->user->doesntHavePermission('admin.pages'));
+        $this->assertFalse($this->user->doesntHavePermission('admin.users'));
+        $this->assertTrue($this->user->doesntHavePermission('admin.config', 'team_a'));
+
         $this->assertTrue($this->user->hasPermission(['admin.*']));
         $this->assertTrue($this->user->hasPermission(['admin.*']));
         $this->assertTrue($this->user->hasPermission(['config.*'], 'team_a'));
         $this->assertTrue($this->user->hasPermission(['config.*']));
         $this->assertFalse($this->user->hasPermission(['site.*']));
+
+        $this->assertFalse($this->user->doesntHavePermission(['admin.*']));
+        $this->assertFalse($this->user->doesntHavePermission(['admin.*']));
+        $this->assertFalse($this->user->doesntHavePermission(['config.*'], 'team_a'));
+        $this->assertFalse($this->user->doesntHavePermission(['config.*']));
+        $this->assertTrue($this->user->doesntHavePermission(['site.*']));
     }
 
     public function userDisableTheRolesAndPermissionsCachingAssertions()

--- a/tests/LaratrustFacadeTest.php
+++ b/tests/LaratrustFacadeTest.php
@@ -46,6 +46,18 @@ class LaratrustFacadeTest extends LaratrustTestCase
         $this->assertFalse($this->laratrust->hasPermission('any_permission'));
     }
 
+    public function testDoesntHavePermission()
+    {
+        $this->laratrust->shouldReceive('user')->andReturn($this->user)->twice()->ordered();
+        $this->laratrust->shouldReceive('user')->andReturn(null)->once()->ordered();
+        $this->user->shouldReceive('hasPermission')->with('user_can', null, false)->andReturn(true)->once();
+        $this->user->shouldReceive('hasPermission')->with('user_cannot', null, false)->andReturn(false)->once();
+
+        $this->assertFalse($this->laratrust->doesntHavePermission('user_can'));
+        $this->assertTrue($this->laratrust->doesntHavePermission('user_cannot'));
+        $this->assertTrue($this->laratrust->doesntHavePermission('any_permission'));
+    }
+
     public function testIsAbleTo()
     {
         $this->laratrust->shouldReceive('user')->andReturn($this->user)->twice()->ordered();
@@ -56,6 +68,18 @@ class LaratrustFacadeTest extends LaratrustTestCase
         $this->assertTrue($this->laratrust->isAbleTo('user_can'));
         $this->assertFalse($this->laratrust->isAbleTo('user_cannot'));
         $this->assertFalse($this->laratrust->isAbleTo('any_permission'));
+    }
+
+    public function testIsNotAbleTo()
+    {
+        $this->laratrust->shouldReceive('user')->andReturn($this->user)->twice()->ordered();
+        $this->laratrust->shouldReceive('user')->andReturn(null)->once()->ordered();
+        $this->user->shouldReceive('hasPermission')->with('user_can', null, false)->andReturn(true)->once();
+        $this->user->shouldReceive('hasPermission')->with('user_cannot', null, false)->andReturn(false)->once();
+
+        $this->assertFalse($this->laratrust->isNotAbleTo('user_can'));
+        $this->assertTrue($this->laratrust->isNotAbleTo('user_cannot'));
+        $this->assertTrue($this->laratrust->isNotAbleTo('any_permission'));
     }
 
     public function testAbility()

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -149,7 +149,7 @@ class UserTest extends LaratrustTestCase
         | Expectation
         |------------------------------------------------------------
         */
-        $user->shouldReceive('hasPermission')->with('manage_user', null, false)->andReturn(true)->once();
+        $user->shouldReceive('hasPermission')->with('manage_user', null, false)->andReturn(true)->twice();
 
         /*
         |------------------------------------------------------------

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -157,6 +157,7 @@ class UserTest extends LaratrustTestCase
         |------------------------------------------------------------
         */
         $this->assertTrue($user->isAbleTo('manage_user'));
+        $this->assertFalse($user->isNotAbleTo('manage_user'));
     }
 
     public function testAddRole()


### PR DESCRIPTION
In my projects, I use the `hasPermission` a lot, but I almost always inverse the result as I want to check if a user doesn't have a permission:
```php
class PostPolicy
{
    public function create(User $user)
    {
        if (! $user->hasPermission('some_permission')) {
            return false;
        }

       // more if-statements that check other conditions

       return true;
    }
}
```
This PR adds dedicated a `doesntHavePermission` method (and `isNotAbleTo` method), so those kind of checks are a bit more readable:

```php
class PostPolicy
{
    public function create(User $user)
    {
        if ($user->doesntHavePermission('some_permission')) {
            return false;
        }

       // more if-statements that check other conditions

       return true;
    }
}
```