### PR TITLE
Avoid potential N+1 queries when fetching user roles

### DIFF
--- a/src/Checkers/User/UserDefaultChecker.php
+++ b/src/Checkers/User/UserDefaultChecker.php
@@ -153,11 +153,11 @@ class UserDefaultChecker extends UserChecker
         $cacheKey = 'laratrust_roles_for_'.$this->userModelCacheKey().'_'.$this->user->getKey();
 
         if (! Config::get('laratrust.cache.enabled')) {
-            return $this->user->roles()->get()->toArray();
+            return $this->user->getRelationValue('roles')->toArray();
         }
 
         return Cache::remember($cacheKey, Config::get('laratrust.cache.expiration_time', 60), function () {
-            return $this->user->roles()->get()->toArray();
+            return $this->user->getRelationValue('roles')->toArray();
         });
     }
 


### PR DESCRIPTION
I came across a situation where the way the user roles were fetched introduced N+1 queries in my application.

By changing the way user relations are fetched from `user->roles()->get()` to `user->getRelationValue('roles')`, we can use the potentially eagerly loaded roles-relation and avoid having to do too many database queries when the data is already available.