### PR TITLE
Typehint actual Builder model

### DIFF
--- a/src/Traits/HasLaratrustScopes.php
+++ b/src/Traits/HasLaratrustScopes.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laratrust\Traits;
 
 use BackedEnum;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Config;
 use Laratrust\Helper;
 use Laratrust\Models\Team;


### PR DESCRIPTION
Fix for false-positive IDE errors when doing e.g. `User::whereHasPermission(...)->get()`, where the `get` method is not recognized by the IDE.