### PR TITLE
fix removal of many-to-many records when deleting user by fixing HasRolesAndPermissions boot method name

### DIFF
--- a/src/Traits/HasRolesAndPermissions.php
+++ b/src/Traits/HasRolesAndPermissions.php
@@ -27,7 +27,7 @@ trait HasRolesAndPermissions
      * remove the many-to-many records when trying to delete.
      * Will NOT delete any records if the user model uses soft deletes.
      */
-    public static function bootLaratrustUserTrait(): void
+    public static function bootHasRolesAndPermissions(): void
     {
         $flushCache = function ($user) {
             $user->flushCache();

--- a/tests/Checkers/Model/LaratrustModelCheckerTestCase.php
+++ b/tests/Checkers/Model/LaratrustModelCheckerTestCase.php
@@ -22,14 +22,15 @@ class LaratrustModelCheckerTestCase extends LaratrustTestCase
         parent::setUp();
 
         $this->migrate();
-        $this->user = User::create(['name' => 'test', 'email' => 'test@test.com']);
-        $this->other = Other::create(['name' => 'test', 'email' => 'test@test.com']);
 
         $this->app['config']->set('laratrust.use_morph_map', true);
         $this->app['config']->set('laratrust.user_models', [
             'users' => 'Laratrust\Tests\Models\User',
             'others' => 'Laratrust\Tests\Models\Other'
         ]);
+
+        $this->user = User::create(['name' => 'test', 'email' => 'test@test.com']);
+        $this->other = Other::create(['name' => 'test', 'email' => 'test@test.com']);
     }
 
     public function modelDisableTheRolesAndPermissionsCachingAssertions()

--- a/tests/Models/Other.php
+++ b/tests/Models/Other.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Laratrust\Tests\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Laratrust\Traits\LaratrustUserTrait;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laratrust\Contracts\LaratrustUser;
 use Laratrust\Traits\HasRolesAndPermissions;
 
-class Other extends Model implements LaratrustUser
+class Other extends Authenticatable implements LaratrustUser
 {
     use HasRolesAndPermissions;
     use SoftDeletes;

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -646,6 +646,42 @@ class UserTest extends LaratrustTestCase
 
     }
 
+    public function testManyToManyRecordsAreRemoved()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        $roleA = Role::create(['name' => 'role_a']);
+        $permissionA = Permission::create(['name' => 'permission_a']);
+
+        $teamA = Team::create(['name' => 'team_a']);
+
+        $this->user->addRole($roleA, $teamA);
+        $this->user->givePermission($permissionA);
+
+        // force-deleting because the user model has soft-deletes enabled
+        $this->user->forceDelete();
+
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->assertModelMissing($this->user);
+
+        $this->assertDatabaseMissing(
+            $this->app['config']->get('laratrust.tables.role_user'),
+            ['user_id' => $this->user->id]
+        );
+
+        $this->assertDatabaseMissing(
+            $this->app['config']->get('laratrust.tables.permission_user'),
+            ['user_id' => $this->user->id]
+        );
+    }
+
     protected function assertWasAttached($objectName, $result)
     {
         $relationship = \Illuminate\Support\Str::plural($objectName);


### PR DESCRIPTION
This PR fixes the HasRolesAndPermissions boot method name, which fixes a.o. the behavior of removing many-to-many records when deleting a user. 

I noticed this behavior was broken when upgrading of one of my apps from Laratrust 7 to 8. During this upgrade one of the tests in the app's test suite started failing. The failing test checks if many-to-many records (e.g. roles) are being removed when deleting a user. Upon further inspection I noticed that the current boot method for the HasRolesAndPermissions still reflects the old trait name (LaratrustUserTrait). By updating the boot method name to the new name, the expected behaviour of removing many-to-many records started working again. 

Also included is a test. This test fails with the old boot method name, but passes with the new boot method name.