### PR TITLE
Add support for custom user model cache keys

### DIFF
--- a/src/Checkers/Role/RoleDefaultChecker.php
+++ b/src/Checkers/Role/RoleDefaultChecker.php
@@ -62,7 +62,15 @@ class RoleDefaultChecker extends RoleChecker
      */
     public function currentRoleCachedPermissions(): array
     {
-        $cacheKey = 'laratrust_permissions_for_role_'.$this->role->getKey();
+        $roleCacheKey = '';
+
+        if(method_exists($this->role, 'roleCacheKey')) {
+            $roleCacheKey = $this->role->roleCacheKey().'_'.$this->role->getKey();
+        }else{
+            $roleCacheKey = $this->role->getKey();
+        }
+
+        $cacheKey = 'laratrust_permissions_for_role_'.$roleCacheKey;
 
         if (! Config::get('laratrust.cache.enabled')) {
             return $this->role->permissions()->get()->toArray();

--- a/src/Checkers/Role/RoleDefaultChecker.php
+++ b/src/Checkers/Role/RoleDefaultChecker.php
@@ -65,14 +65,14 @@ class RoleDefaultChecker extends RoleChecker
         $roleCacheKey = '';
 
         if (method_exists($this->role, 'roleCacheKey')) {
-            $roleCacheKey = $this->role->roleCacheKey() . '_' . $this->role->getKey();
+            $roleCacheKey = $this->role->roleCacheKey().'_'.$this->role->getKey();
         } else {
             $roleCacheKey = $this->role->getKey();
         }
 
-        $cacheKey = 'laratrust_permissions_for_role_' . $roleCacheKey;
+        $cacheKey = 'laratrust_permissions_for_role_'.$roleCacheKey;
 
-        if (!Config::get('laratrust.cache.enabled')) {
+        if (! Config::get('laratrust.cache.enabled')) {
             return $this->role->permissions()->get()->toArray();
         }
 

--- a/src/Checkers/Role/RoleDefaultChecker.php
+++ b/src/Checkers/Role/RoleDefaultChecker.php
@@ -64,15 +64,15 @@ class RoleDefaultChecker extends RoleChecker
     {
         $roleCacheKey = '';
 
-        if(method_exists($this->role, 'roleCacheKey')) {
-            $roleCacheKey = $this->role->roleCacheKey().'_'.$this->role->getKey();
-        }else{
+        if (method_exists($this->role, 'roleCacheKey')) {
+            $roleCacheKey = $this->role->roleCacheKey() . '_' . $this->role->getKey();
+        } else {
             $roleCacheKey = $this->role->getKey();
         }
 
-        $cacheKey = 'laratrust_permissions_for_role_'.$roleCacheKey;
+        $cacheKey = 'laratrust_permissions_for_role_' . $roleCacheKey;
 
-        if (! Config::get('laratrust.cache.enabled')) {
+        if (!Config::get('laratrust.cache.enabled')) {
             return $this->role->permissions()->get()->toArray();
         }
 

--- a/src/Checkers/User/UserDefaultChecker.php
+++ b/src/Checkers/User/UserDefaultChecker.php
@@ -190,6 +190,10 @@ class UserDefaultChecker extends UserChecker
      */
     public function userModelCacheKey(): string
     {
+        if (method_exists($this->user, 'laratrustCacheKey')) {
+            return $this->user->laratrustCacheKey();
+        }
+
         foreach (Config::get('laratrust.user_models') as $key => $model) {
             if ($this->user instanceof $model) {
                 return $key;


### PR DESCRIPTION
This PR allows the user model to define a custom cache key by implementing the laratrustCacheKey() method. This provides more flexibility than relying solely on the configuration file.

Why is this necessary?
This is particularly useful for Multi-tenant systems. In such environments, the same user model might need a dynamic cache key that includes the tenant_id to prevent cache collisions between different tenants.